### PR TITLE
fix(authelia): add groups claims_policy for grafana oidc

### DIFF
--- a/kubernetes/apps/security/authelia/app/resources/configuration.yaml
+++ b/kubernetes/apps/security/authelia/app/resources/configuration.yaml
@@ -64,6 +64,9 @@ identity_providers:
     cors:
       endpoints: ["authorization", "token", "revocation", "introspection"]
       allowed_origins_from_client_redirect_uris: true
+    claims_policies:
+      grafana:
+        id_token: [groups, email, email_verified, name, preferred_username]
     clients:
       - client_name: actual
         client_id: "${ACTUAL_OAUTH_CLIENT_ID}"
@@ -91,6 +94,7 @@ identity_providers:
         pre_configured_consent_duration: 1y
         scopes: ["openid", "profile", "groups", "email"]
         redirect_uris: ["https://grafana.perryhuynh.com/login/generic_oauth"]
+        claims_policy: grafana
         userinfo_signed_response_alg: none
       - client_name: paperless
         client_id: "${PAPERLESS_OAUTH_CLIENT_ID}"


### PR DESCRIPTION
## Problem
Post grafana-operator migration, Authelia login works but `perry` lands as **Viewer** (dashboards visible, datasources/admin not).

## Root cause
- `perry` is correctly in glauth `admins` group (`othergroups=[6501]`).
- Grafana CR role mapping is correct: `contains(groups[*], 'admins') && 'GrafanaAdmin' || 'Viewer'` with `allow_assign_grafana_admin`.
- Grafana's access token is opaque (`authelia_at_...`), so Grafana reads role off the **ID token**.
- **Authelia 4.39 omits standard claims (`groups`, `email`, `name`, …) from the ID token by default** — needs a `claims_policy`. None existed → Grafana saw no `groups` → everyone Viewer.

## Fix
Add a `claims_policies.grafana` injecting `groups` (plus email/name/preferred_username) into the ID token, scoped to the grafana client only.

## Verify
After Flux reconciles + Authelia rolls: re-login to grafana.perryhuynh.com → datasources + Server Admin visible.