### PR TITLE
feat(scrypted): restore on iot vlan with upstream rootless image

### DIFF
--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
   - ./namespace.yaml
   - ./go2rtc/ks.yaml
   - ./home-assistant/ks.yaml
+  - ./scrypted/ks.yaml
   - ./teslamate/ks.yaml

--- a/kubernetes/apps/home/scrypted/app/helmrelease.yaml
+++ b/kubernetes/apps/home/scrypted/app/helmrelease.yaml
@@ -1,0 +1,117 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app scrypted
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: scrypted
+  values:
+    controllers:
+      scrypted:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            env:
+              SCRYPTED_INSECURE_PORT: &port 80
+            image:
+              repository: ghcr.io/koush/scrypted
+              tag: v0.144.1-noble-intel@sha256:c7f6ef12613922ae1736c007e74285c617a52e6f3d5af33daa195a6dd617e74a
+            command:
+              - "npm"
+            args:
+              - "--prefix"
+              - "/server"
+              - "exec"
+              - "scrypted-serve"
+            resources:
+              claims:
+                - name: gpu
+              limits:
+                memory: 8Gi
+              requests:
+                cpu: 100m
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - "ALL"
+              readOnlyRootFilesystem: true
+    defaultPodOptions:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |
+          [{
+            "name": "iot",
+            "namespace": "networking",
+            "ips": ["192.168.50.4/24"],
+            "mac": "a6:42:05:ea:fc:5b"
+          }]
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - wizone
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: scrypted
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups:
+          - 44
+          - 109
+    persistence:
+      config:
+        existingClaim: scrypted
+        globalMounts:
+          - path: /server/volume
+      plugins:
+        existingClaim: scrypted-plugins
+        globalMounts:
+          - path: /server/volume/plugins
+      recs:
+        type: nfs
+        path: /mnt/tank/media
+        server: nas.home.arpa
+        globalMounts:
+          - path: /recs
+            subPath: scrypted
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          scrypted:
+            app:
+              - path: /.cache
+                subPath: cache
+              - path: /home/ubuntu/.npm
+                subPath: npm
+              - path: /tmp
+                subPath: tmp
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.perryhuynh.com"
+        parentRefs:
+          - name: envoy-internal
+            namespace: networking
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/home/scrypted/app/kustomization.yaml
+++ b/kubernetes/apps/home/scrypted/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./resourceclaimtemplate.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/home/scrypted/app/ocirepository.yaml
+++ b/kubernetes/apps/home/scrypted/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: scrypted
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token.actions.githubusercontent.com$"
+        subject: "^https://github.com/bjw-s-labs/helm-charts.*$"

--- a/kubernetes/apps/home/scrypted/app/pvc.yaml
+++ b/kubernetes/apps/home/scrypted/app/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: scrypted-plugins
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/home/scrypted/app/resourceclaimtemplate.yaml
+++ b/kubernetes/apps/home/scrypted/app/resourceclaimtemplate.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: scrypted
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com

--- a/kubernetes/apps/home/scrypted/ks.yaml
+++ b/kubernetes/apps/home/scrypted/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app scrypted
+  namespace: &namespace home
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: intel-gpu-resource-driver
+      namespace: kube-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: multus-networks
+      namespace: networking
+  interval: 1h
+  path: ./kubernetes/apps/home/scrypted/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true


### PR DESCRIPTION
## What

Restore scrypted (NVR / HomeKit camera bridge), removed in #5828, modernized to current repo conventions.

## Changes

- New app at `kubernetes/apps/home/scrypted/`, wired into the `home` namespace.
- **GPU**: inline `ResourceClaimTemplate` (`gpu.intel.com`) — old `components/gpu` is gone.
- **Network**: `iot` multus VLAN, IP `192.168.50.4/24` (bumped from go2rtc's `.3`), new MAC.
- **Storage**: `volsync` component (config PVC) + `scrypted-plugins` PVC; NFS `recs` mount.
- Dropped dead `keda/nfs-scaler`; home-operations schemas; cosign-verified app-template OCIRepository `5.0.1`.
- **No LoadBalancer** — ClusterIP only; HomeKit/rebroadcast advertised over the pod's iot multus IP.

## Image: upstream rootless

Switched to `ghcr.io/koush/scrypted:v0.144.1-noble-intel` (Intel QSV flavor).

Verified locally that upstream runs rootless **only** with a custom entrypoint that bypasses the s6 `/init`:

- Plain rootless → fails (`s6-overlay-suexec: unable to gain root privileges`).
- `command: npm` / `args: --prefix /server exec scrypted-serve` → starts clean as uid 1000, `readOnlyRootFilesystem`, all caps dropped: `Scrypted Server (Local): https://localhost:10443/`. Needs writable `/server/volume` (PVC + `fsGroup: 1000` provides it).

## Verification

`flate test all --path kubernetes/flux/cluster --log-level error` → 312 passed, 0 failed.