### PR TITLE
feat(media): increase plex PVC from 50Gi to 100Gi

### DIFF
--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -29,7 +29,7 @@ spec:
     substitute:
       APP: *app
       GATUS_PATH: /identity
-      VOLSYNC_CAPACITY: 50Gi
+      VOLSYNC_CAPACITY: 100Gi
     substituteFrom:
       - kind: Secret
         name: plex


### PR DESCRIPTION
## Summary
- PVC at 86.7% capacity (~42.4 GiB used of 48.9 GiB), ~6.5 GiB free
- Increases `VOLSYNC_CAPACITY` from `50Gi` → `100Gi` in `ks.yaml`

## Test plan
- [ ] Flux reconciles Kustomization successfully
- [ ] PVC expands without pod restart issues