### PR TITLE
fix(database): alias barman cloud metrics to cnpg_collector names

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/prometheusrule.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/prometheusrule.yaml
@@ -9,6 +9,12 @@ metadata:
     role: alert-rules
 spec:
   groups:
+    - name: cloudnative-pg.recording-rules
+      rules:
+        - record: cnpg_collector_last_available_backup_timestamp
+          expr: barman_cloud_cloudnative_pg_io_last_available_backup_timestamp
+        - record: cnpg_collector_first_recoverability_point
+          expr: barman_cloud_cloudnative_pg_io_first_recoverability_point
     - name: cloudnative-pg.rules
       rules:
         - alert: LongRunningTransaction


### PR DESCRIPTION
## Summary
- After migrating CNPG to the barman cloud plugin, `cnpg_collector_last_available_backup_timestamp` and `cnpg_collector_first_recoverability_point` return `0` — the plugin publishes them under the `barman_cloud_cloudnative_pg_io_*` prefix instead
- Adds recording rules to alias the new names back to the old `cnpg_collector_*` names so the upstream CloudNativePG Grafana dashboard works without forking it
- Existing `PGNoRecentBackups` alert is unaffected (already uses the barman name directly)

## Test plan
- [x] Recording rules appear in VictoriaMetrics
- [x] `cnpg_collector_last_available_backup_timestamp` returns non-zero values
- [x] `cnpg_collector_first_recoverability_point` returns non-zero values
- [x] Grafana "Last Base Backup" and "First Recoverability Point" panels show data