### PR TITLE
fix(observability): fix UPS dashboard battery metrics and sync alert rules

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/ups/prometheusrule.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/ups/prometheusrule.yaml
@@ -6,13 +6,20 @@ metadata:
   name: snmp-exporter-ups-rules
 spec:
   groups:
+    - name: snmp-exporter-ups.recording-rules
+      rules:
+        - record: upsAdvBatteryRunTimeRemaining
+          expr: upsAdvBatteryRunTimeRemaining_seconds * 100
+        - record: upsBasicBatteryTimeOnBattery
+          expr: upsBasicBatteryTimeOnBattery_seconds * 100
     - name: snmp-exporter-ups.rules
       rules:
         - alert: UPSOnBattery
-          annotations:
-            summary: ZPM {{$labels.instance}} is running on batteries and has less than 60 minutes of battery left
           expr: upsBasicBatteryTimeOnBattery_seconds > 60
-          for: 1m
+          annotations:
+            summary: >-
+              ZPM {{$labels.instance}} is running on batteries
+          for: 5m
           labels:
             severity: critical
         - alert: UPSReplaceBattery


### PR DESCRIPTION
## Summary
- Adds recording rules to alias `upsAdvBatteryRunTimeRemaining_seconds` and `upsBasicBatteryTimeOnBattery_seconds` back to their old timetick names (`* 100`), fixing the "Estimated uptime on batteries" and "Time spent on battery" panels in the APC UPS Grafana dashboard without forking it
- Syncs `UPSOnBattery` alert with [onedr0p/home-ops](https://github.com/onedr0p/home-ops/blob/main/kubernetes/apps/o11y/snmp-exporter/app/prometheusrule.yaml): simplified summary text, `for` increased from `1m` → `5m`
- Note: `sysUpTime` (UPS uptime panel) has no equivalent metric in the current SNMP module — that panel remains broken

## Test plan
- [x] `upsAdvBatteryRunTimeRemaining` and `upsBasicBatteryTimeOnBattery` appear in VictoriaMetrics
- [x] APC UPS dashboard "Estimated uptime on batteries" and "Time spent on battery" panels show data