### PR TITLE
feat(cilium): enable hubble metrics

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -39,7 +39,17 @@ spec:
     envoy:
       enabled: false
     hubble:
-      enabled: false
+      enabled: true
+      metrics:
+        enabled:
+          - dns
+          - drop
+          - tcp
+          - flow
+          - port-distribution
+          - icmp
+        serviceMonitor:
+          enabled: true
     ipam:
       mode: kubernetes
     ipv4NativeRoutingCIDR: "10.42.0.0/16"


### PR DESCRIPTION
## Summary
- Enables Hubble with dns, drop, tcp, flow, port-distribution, and icmp metrics
- ServiceMonitor enabled for VictoriaMetrics scraping
- No relay or UI — metrics-only, safe for bootstrap ordering

## Test plan
- [ ] Flux reconciles cilium HelmRelease without errors
- [ ] `hubble_*` metrics appear in VictoriaMetrics