### PR TITLE
feat(cilium): enable hubble grafana dashboard

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/grafanadashboard.yaml
@@ -28,3 +28,18 @@ spec:
   configMapRef:
     name: cilium-operator-dashboard
     key: cilium-operator-dashboard.json
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: hubble
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  folder: kube-system
+  configMapRef:
+    name: hubble-dashboard
+    key: hubble-dashboard.json

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -41,6 +41,8 @@ spec:
     hubble:
       enabled: true
       metrics:
+        dashboards:
+          enabled: true
         enabled:
           - dns
           - drop


### PR DESCRIPTION
## Summary
Follow-up to #7050 (hubble metrics). Cilium chart ships a dedicated Hubble dashboard gated behind `hubble.metrics.dashboards.enabled`, separate from the already-enabled agent (`dashboards.enabled`) and operator (`operator.dashboards.enabled`) dashboards.

- Set `hubble.metrics.dashboards.enabled: true` → chart creates `hubble-dashboard` ConfigMap
- Added `hubble` GrafanaDashboard CRD referencing that ConfigMap (`kube-system` folder), matching the existing cilium/cilium-operator dashboard pattern

Dashboard covers the enabled hubble metrics: dns, drop, tcp, flow, port-distribution, icmp.

## Validation
`flate build hr -p kubernetes/flux/cluster -n kube-system` renders the `hubble-dashboard` ConfigMap and `hubble-dashboard.json` key.