### PR TITLE
feat(cilium): add workload context to hubble metrics

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -44,12 +44,12 @@ spec:
         dashboards:
           enabled: true
         enabled:
-          - dns
-          - drop
-          - tcp
-          - flow
-          - port-distribution
-          - icmp
+          - "flow:labelsContext=source_namespace,source_workload,destination_namespace,destination_workload"
+          - "drop:sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity;labelsContext=source_namespace,source_workload,destination_namespace,destination_workload"
+          - "tcp:labelsContext=source_namespace,source_workload,destination_namespace,destination_workload"
+          - "icmp"
+          - "port-distribution"
+          - "flows-to-world:any-drop;port"
         serviceMonitor:
           enabled: true
     ipam:


### PR DESCRIPTION
## Summary
Follow-up to #7050/#7051. Adds source/destination **workload** + namespace context to Hubble metrics so traffic can be sliced by app and namespace for debugging via the metrics MCP.

| Metric | Change | Why |
|---|---|---|
| `flow` | `labelsContext=source/destination namespace+workload` | per-app traffic matrix, bounded cardinality |
| `drop` | `sourceContext`/`destinationContext=workload-name\|reserved-identity` + workload `labelsContext` | **fixes the dashboard's "Top 10 Source/Destination Pods with Denied Packets" panels** (populate `source`/`destination` labels); `reserved-identity` labels world/host traffic instead of leaving it blank |
| `tcp` | workload `labelsContext` | per-app retransmit / SYN-ACK debugging |
| `flows-to-world` | **new** (`any-drop;port`) | egress-to-world visibility (catch apps phoning home) |
| `dns` | **removed** | produced zero series — no L7 DNS visibility (no DNS-proxy policy) |

Workload chosen over namespace (too coarse — collapses all media apps) and pod (ephemeral names → cardinality churn). Workload = stable Deployment/StatefulSet name.

## Not included (intentional)
- **DNS panels** stay empty — need L7 DNS visibility (FQDN/L7 CiliumNetworkPolicy). Separate decision.
- **HTTP panels** stay empty — need `envoy.enabled: true` (currently disabled by design) + mostly defeated by HTTPS.

## Example MCP queries unlocked
\`\`\`promql
sum by (destination_workload) (rate(hubble_flows_processed_total{source_workload="sonarr"}[5m]))
topk(10, sum by (source) (rate(hubble_drop_total{destination_namespace="media",reason="POLICY_DENIED"}[5m])))
\`\`\`

## Validation
\`flate build hr -p kubernetes/flux/cluster -n kube-system\` renders the updated \`hubble-metrics\` config cleanly.

⚠️ Cardinality: workload pairs on flow/drop/tcp raise hubble series count (~few hundred → ~1k at this cluster's scale, ~17 ns / ~191 pods). Worth a glance at VM TSDB after rollout.