### PR TITLE
feat(observability): add victoriatraces trace backend

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -25,3 +25,4 @@ resources:
   - ./unpoller/ks.yaml
   - ./victoria-metrics/ks.yaml
   - ./victoria-logs/ks.yaml
+  - ./victoria-traces/ks.yaml

--- a/kubernetes/apps/observability/opentelemetry/collector/opentelemetrycollector.yaml
+++ b/kubernetes/apps/observability/opentelemetry/collector/opentelemetrycollector.yaml
@@ -223,6 +223,10 @@ spec:
         metrics_endpoint: &metrics_endpoint http://victoria-metrics.observability.svc.cluster.local:8428/opentelemetry/v1/metrics
         sending_queue:
           storage: file_storage
+      otlp_http/traces:
+        traces_endpoint: http://victoria-traces.observability.svc.cluster.local:10428/insert/opentelemetry/v1/traces
+        sending_queue:
+          storage: file_storage
     service:
       extensions:
         - file_storage
@@ -244,6 +248,14 @@ spec:
             - batch
           exporters:
             - otlp_http/metrics
+        traces:
+          receivers:
+            - otlp
+          processors:
+            - memory_limiter
+            - batch
+          exporters:
+            - otlp_http/traces
       telemetry:
         metrics:
           readers:

--- a/kubernetes/apps/observability/victoria-traces/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/victoria-traces/app/grafanadashboard.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: victoria-traces-single
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  folder: observability
+  url: https://grafana.com/api/dashboards/24136/revisions/3/download

--- a/kubernetes/apps/observability/victoria-traces/app/grafanadatasource.yaml
+++ b/kubernetes/apps/observability/victoria-traces/app/grafanadatasource.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadatasource_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: victoriatraces
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasource:
+    name: VictoriaTraces
+    type: jaeger
+    access: proxy
+    url: http://victoria-traces.observability.svc.cluster.local:10428

--- a/kubernetes/apps/observability/victoria-traces/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-traces/app/helmrelease.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-traces
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: victoria-traces
+  interval: 1h
+  values:
+    global:
+      image:
+        registry: mirror.gcr.io
+    server:
+      fullnameOverride: victoria-traces
+      retentionPeriod: 30d
+      persistentVolume:
+        enabled: true
+        storageClassName: ceph-block
+        size: 20Gi
+      resources:
+        limits:
+          memory: 1Gi
+        requests:
+          cpu: 10m
+      route:
+        enabled: true
+        hostnames:
+          - traces.perryhuynh.com
+        parentRefs:
+          - name: envoy-internal
+            namespace: networking
+            sectionName: https
+      serviceMonitor:
+        enabled: true

--- a/kubernetes/apps/observability/victoria-traces/app/kustomization.yaml
+++ b/kubernetes/apps/observability/victoria-traces/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./grafanadashboard.yaml
+  - ./grafanadatasource.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/observability/victoria-traces/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/victoria-traces/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: victoria-traces
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.8
+  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-traces-single
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token.actions.githubusercontent.com$"
+        subject: "^https://github.com/VictoriaMetrics/helm-charts.*$"

--- a/kubernetes/apps/observability/victoria-traces/ks.yaml
+++ b/kubernetes/apps/observability/victoria-traces/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app victoria-traces
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/observability/victoria-traces/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true


### PR DESCRIPTION
## Summary
Adds **VictoriaTraces** as the cluster's trace store, completing the third observability signal alongside VictoriaMetrics (metrics) and VictoriaLogs (logs). Deployed in the same Flux/HelmRelease fashion as VL/VM.

**This PR is the backend + ingest path only — no producers yet.** Nothing emits traces, so it's safe to reconcile standalone. Instrumentation follows in later PRs.

## Changes
- **`victoria-traces/`** — new app mirroring `victoria-logs`:
  - `OCIRepository` `victoria-traces-single` `0.1.8` with cosign `matchOIDCIdentity` verification
  - `HelmRelease`: `ceph-block` PVC (20Gi), `retentionPeriod: 30d`, internal route `traces.perryhuynh.com` via `envoy-internal`, `serviceMonitor` enabled
  - `GrafanaDatasource` (type `jaeger`) → `http://victoria-traces…:10428` for exploring traces
  - `GrafanaDashboard` → upstream single-node self-monitoring dashboard (grafana.com/24136)
  - registered in `observability/kustomization.yaml`
- **gateway collector** (`opentelemetry/collector/opentelemetrycollector.yaml`): new `traces` pipeline reusing the existing OTLP receiver, exporting via `otlp_http/traces` to `http://victoria-traces…:10428/insert/opentelemetry/v1/traces` (file-storage-backed sending queue, matching the logs/metrics exporters).

## Deferred to follow-up PRs
- Multi-language `Instrumentation` CRD under `opentelemetry/instrumentation` + Flux Kustomization
- Pod annotations on the media arr stack + seerr
- Beyla eBPF DaemonSet (Go + closed-source HTTP coverage)
- OTel operator nodejs auto-instr image typo fix

## Validation
- `flate test all --path kubernetes/flux/cluster` → **308 passed, 0 failed**
- Rendered gateway carries the `otlp_http/traces` exporter + `traces` pipeline; VictoriaTraces serves `--httpListenAddr=:10428`.

Post-merge: confirm `victoria-traces` pod Running + PVC bound, `traces.perryhuynh.com` reachable, Jaeger datasource present in Grafana. No spans until producers land.