### PR TITLE
feat(observability): wire up trace producers (instrumentation + beyla)

### DIFF
--- a/kubernetes/apps/media/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/autobrr/app/helmrelease.yaml
@@ -69,6 +69,8 @@ spec:
               requests:
                 cpu: 10m
     defaultPodOptions:
+      annotations:
+        beyla.instrument: "true"
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -73,6 +73,8 @@ spec:
               requests:
                 cpu: 10m
     defaultPodOptions:
+      annotations:
+        instrumentation.opentelemetry.io/inject-dotnet: observability/multilang
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -75,6 +75,7 @@ spec:
     defaultPodOptions:
       annotations:
         instrumentation.opentelemetry.io/inject-dotnet: observability/multilang
+        instrumentation.opentelemetry.io/otel-dotnet-auto-runtime: linux-musl-x64
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/media/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qui/app/helmrelease.yaml
@@ -70,6 +70,8 @@ spec:
                   - "ALL"
               readOnlyRootFilesystem: true
     defaultPodOptions:
+      annotations:
+        beyla.instrument: "true"
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -77,6 +77,7 @@ spec:
     defaultPodOptions:
       annotations:
         instrumentation.opentelemetry.io/inject-dotnet: observability/multilang
+        instrumentation.opentelemetry.io/otel-dotnet-auto-runtime: linux-musl-x64
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -75,6 +75,8 @@ spec:
               requests:
                 cpu: 10m
     defaultPodOptions:
+      annotations:
+        instrumentation.opentelemetry.io/inject-dotnet: observability/multilang
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -60,6 +60,8 @@ spec:
                   - "ALL"
               readOnlyRootFilesystem: true
     defaultPodOptions:
+      annotations:
+        instrumentation.opentelemetry.io/inject-nodejs: observability/multilang
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -77,6 +77,7 @@ spec:
     defaultPodOptions:
       annotations:
         instrumentation.opentelemetry.io/inject-dotnet: observability/multilang
+        instrumentation.opentelemetry.io/otel-dotnet-auto-runtime: linux-musl-x64
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -75,6 +75,8 @@ spec:
                   failureThreshold: 30
                   periodSeconds: 10
     defaultPodOptions:
+      annotations:
+        instrumentation.opentelemetry.io/inject-dotnet: observability/multilang
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/observability/beyla/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/beyla/app/helmrelease.yaml
@@ -24,10 +24,10 @@ spec:
         attributes:
           kubernetes:
             enable: true
-        # Scope instrumentation to the media namespace to bound overhead
         discovery:
           instrument:
-            - k8s_namespace: media
+            - k8s_pod_annotations:
+                beyla.instrument: "true"
         # Export traces to the central OTel gateway collector (OTLP/HTTP)
         otel_traces_export:
           endpoint: http://gateway-collector.observability.svc.cluster.local:4318

--- a/kubernetes/apps/observability/beyla/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/beyla/app/helmrelease.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: beyla
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: beyla
+  interval: 1h
+  values:
+    # Application observability: RED metrics + HTTP/gRPC trace spans
+    preset: application
+    serviceMonitor:
+      enabled: true
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 50m
+    config:
+      data:
+        attributes:
+          kubernetes:
+            enable: true
+        # Scope instrumentation to the media namespace to bound overhead
+        discovery:
+          instrument:
+            - k8s_namespace: media
+        # Export traces to the central OTel gateway collector (OTLP/HTTP)
+        otel_traces_export:
+          endpoint: http://gateway-collector.observability.svc.cluster.local:4318

--- a/kubernetes/apps/observability/beyla/app/kustomization.yaml
+++ b/kubernetes/apps/observability/beyla/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/observability/beyla/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/beyla/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: beyla
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.16.8
+  url: oci://ghcr.io/grafana/helm-charts/beyla

--- a/kubernetes/apps/observability/beyla/ks.yaml
+++ b/kubernetes/apps/observability/beyla/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app beyla
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: opentelemetry-collector
+  interval: 1h
+  path: ./kubernetes/apps/observability/beyla/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -9,6 +9,7 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./beyla/ks.yaml
   - ./blackbox-exporter/ks.yaml
   - ./gatus/ks.yaml
   - ./grafana-mcp/ks.yaml

--- a/kubernetes/apps/observability/opentelemetry/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/opentelemetry/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
             repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java
             tag: "2.27.0@sha256:6d263ee46a3faace8950aec57ad4fd03b70a84169908e5f26eb1e42d92a0a441"
           nodejs:
-            repository: docker pull ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs
+            repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs
             tag: "0.75.0@sha256:be8dec6ee0fd8ba1b217f8a8bc9a13f907e72b9891f5b84f23e234ad586696fc"
           python:
             repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python

--- a/kubernetes/apps/observability/opentelemetry/collector/opentelemetrycollector.yaml
+++ b/kubernetes/apps/observability/opentelemetry/collector/opentelemetrycollector.yaml
@@ -210,6 +210,24 @@ spec:
         check_interval: 1s
         limit_percentage: 75
         spike_limit_percentage: 15
+      tail_sampling:
+        decision_wait: 10s
+        expected_new_traces_per_sec: 50
+        num_traces: 5000
+        policies:
+          - name: errors
+            type: status_code
+            status_code:
+              status_codes:
+                - ERROR
+          - name: slow
+            type: latency
+            latency:
+              threshold_ms: 1000
+          - name: baseline
+            type: probabilistic
+            probabilistic:
+              sampling_percentage: 25
     exporters:
       debug: {}
       otlp_http/logs:
@@ -252,6 +270,7 @@ spec:
             - otlp
           processors:
             - memory_limiter
+            - tail_sampling
             - batch
           exporters:
             - otlp_http/traces

--- a/kubernetes/apps/observability/opentelemetry/collector/opentelemetrycollector.yaml
+++ b/kubernetes/apps/observability/opentelemetry/collector/opentelemetrycollector.yaml
@@ -164,7 +164,6 @@ metadata:
   name: gateway
 spec:
   mode: statefulset
-  replicas: 2
   volumeMounts:
     - mountPath: /var/lib/otelcol/storage
       name: storage

--- a/kubernetes/apps/observability/opentelemetry/instrumentation/instrumentation.yaml
+++ b/kubernetes/apps/observability/opentelemetry/instrumentation/instrumentation.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/opentelemetry.io/instrumentation_v1alpha1.json
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: multilang
+spec:
+  exporter:
+    endpoint: http://gateway-collector.observability.svc.cluster.local:4318
+  env:
+    # Force OTLP/HTTP so every language SDK targets the gateway's 4318 listener
+    - name: OTEL_EXPORTER_OTLP_PROTOCOL
+      value: http/protobuf
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "0.25"

--- a/kubernetes/apps/observability/opentelemetry/instrumentation/instrumentation.yaml
+++ b/kubernetes/apps/observability/opentelemetry/instrumentation/instrumentation.yaml
@@ -11,9 +11,11 @@ spec:
     # Force OTLP/HTTP so every language SDK targets the gateway's 4318 listener
     - name: OTEL_EXPORTER_OTLP_PROTOCOL
       value: http/protobuf
+    # Logs are already collected from stdout by the filelog collector.
+    - name: OTEL_LOGS_EXPORTER
+      value: none
   propagators:
     - tracecontext
     - baggage
   sampler:
-    type: parentbased_traceidratio
-    argument: "0.25"
+    type: parentbased_always_on

--- a/kubernetes/apps/observability/opentelemetry/instrumentation/kustomization.yaml
+++ b/kubernetes/apps/observability/opentelemetry/instrumentation/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./instrumentation.yaml

--- a/kubernetes/apps/observability/opentelemetry/ks.yaml
+++ b/kubernetes/apps/observability/opentelemetry/ks.yaml
@@ -42,3 +42,26 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   wait: true
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app opentelemetry-instrumentation
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: opentelemetry
+    - name: opentelemetry-collector
+  interval: 1h
+  path: ./kubernetes/apps/observability/opentelemetry/instrumentation
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/security/authelia/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authelia/app/helmrelease.yaml
@@ -76,6 +76,9 @@ spec:
               runAsNonRoot: true
               runAsUser: 1000
               runAsGroup: 1000
+    defaultPodOptions:
+      annotations:
+        beyla.instrument: "true"
     persistence:
       config:
         type: configMap

--- a/kubernetes/apps/security/glauth/app/helmrelease.yaml
+++ b/kubernetes/apps/security/glauth/app/helmrelease.yaml
@@ -61,6 +61,8 @@ spec:
               runAsGroup: 65534
               runAsNonRoot: true
     defaultPodOptions:
+      annotations:
+        beyla.instrument: "true"
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## Summary
Follow-up to #7053 (VictoriaTraces backend). Adds trace producers and narrows Beyla to explicit pod annotation opt-in.

## Changes
### OTel SDK auto-instrumentation
- Adds `opentelemetry/instrumentation/` with one multi-language `Instrumentation` CRD (`multilang`) and its own Flux Kustomization.
- Exports OTLP/HTTP to `gateway-collector:4318` and forces `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
- Uses `parentbased_always_on` at the SDK layer so the gateway collector can make tail sampling decisions.
- Sets `OTEL_LOGS_EXPORTER=none`; application logs are already collected from stdout by the filelog collector.
- Adds cross-namespace `observability/multilang` injection annotations:
  - `sonarr`, `radarr`, `prowlarr` -> `inject-dotnet`
  - `seerr` -> `inject-nodejs`
- Sets `instrumentation.opentelemetry.io/otel-dotnet-auto-runtime=linux-musl-x64` for the Alpine/musl-based arr images.
- Fixes the OpenTelemetry operator nodejs auto-instrumentation image repository typo.

### Beyla eBPF instrumentation
- Adds Grafana Beyla `1.16.8` with the `application` preset.
- Switches discovery from namespace-wide `media` matching to pod annotation matching:
  - `beyla.instrument: "true"`
- Adds Beyla opt-in annotations for Go services:
  - `autobrr`
  - `qui`
  - `authelia`
  - `glauth`
- Exports Beyla traces to the central OTel gateway collector over OTLP/HTTP.

### Collector/Gateway
- Leaves Envoy Gateway tracing enabled and exporting OTLP/gRPC to `gateway-collector-headless:4317`.
- Adds gateway collector tail sampling for traces:
  - keep error traces
  - keep traces over 1s
  - keep a 25% probabilistic baseline of the rest
- Drops the explicit gateway collector `replicas: 2`; the OpenTelemetry operator default keeps it at one replica without carrying a redundant field.

## Validation
- `flate test all --path kubernetes/flux/cluster --log-level error` -> `312 passed, 0 failed`

## Post-merge checks
- `kubectl -n media describe pod <sonarr|radarr|prowlarr|seerr>` -> OTel auto-instrumentation init container/env are present, and the arr pods carry the `linux-musl-x64` .NET runtime annotation.
- `kubectl -n media describe pod <autobrr|qui>` -> `beyla.instrument=true` pod annotation is present.
- `kubectl -n security describe pod <authelia|glauth>` -> `beyla.instrument=true` pod annotation is present.
- Traces appear in VictoriaTraces for the SDK-instrumented apps and Beyla-instrumented Go apps.

## Watch items
- .NET arr images are Alpine/musl based (`etc/alpine-release`, `ld-musl`, `libc.musl` present in the pinned images). Confirm the .NET auto-instrumentation init container still attaches cleanly and pods stay healthy with `readOnlyRootFilesystem: true`.
- Beyla is intentionally annotation-scoped to avoid cluster or namespace-wide eBPF overhead/cardinality.
