### PR TITLE
fix(observability): correct traces datasource

### DIFF
--- a/kubernetes/apps/observability/victoria-traces/app/grafanadatasource.yaml
+++ b/kubernetes/apps/observability/victoria-traces/app/grafanadatasource.yaml
@@ -12,4 +12,4 @@ spec:
     name: VictoriaTraces
     type: jaeger
     access: proxy
-    url: http://victoria-traces.observability.svc.cluster.local:10428
+    url: http://victoria-traces.observability.svc.cluster.local:10428/select/jaeger


### PR DESCRIPTION
## Summary
- Point the VictoriaTraces Grafana Jaeger datasource at \/select\/jaeger.
- Fixes Grafana Jaeger Explore calls failing against unsupported VictoriaTraces paths like \/api\/services and \/api\/traces.

## Validation
- `flate test all --path kubernetes\/flux\/cluster --log-level error` -> `312 passed, 0 failed`