### PR TITLE
chore(observability): limit exporter memory

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -105,3 +105,8 @@ spec:
                   storage: 10Gi
     prometheus-node-exporter:
       fullnameOverride: node-exporter
+      resources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 10m

--- a/kubernetes/apps/observability/prometheus-adapter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/prometheus-adapter/app/helmrelease.yaml
@@ -12,6 +12,11 @@ spec:
   values:
     prometheus:
       url: http://prometheus-operated.observability.svc.cluster.local
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 10m
     rules:
       default: false
       external:


### PR DESCRIPTION
## Summary
- add a 64Mi memory limit and 10m CPU request for node-exporter
- add a 128Mi memory limit and 10m CPU request for prometheus-adapter

## Validation
- flate test all --path kubernetes/flux/cluster --log-level error
- 305 passed, 0 skipped, 0 failed