### PR TITLE
chore(observability): limit operator memory

### DIFF
--- a/kubernetes/apps/observability/grafana-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana-operator/app/helmrelease.yaml
@@ -10,5 +10,10 @@ spec:
     kind: OCIRepository
     name: grafana-operator
   values:
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 10m
     serviceMonitor:
       enabled: true

--- a/kubernetes/apps/observability/opentelemetry/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/opentelemetry/app/helmrelease.yaml
@@ -11,6 +11,11 @@ spec:
     name: opentelemetry-operator
   values:
     manager:
+      resources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 10m
       collectorImage:
         repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
         tag: "0.154.0@sha256:b3079f45e19bdb7326bf49cdddce6cf60dfd865138db39f2733ea48ab17bc4cb"

--- a/kubernetes/apps/observability/snmp-exporter/app/ups/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/ups/helmrelease.yaml
@@ -13,6 +13,11 @@ spec:
     fullnameOverride: *app
     image:
       repository: quay.io/prometheus/snmp-exporter
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 10m
     serviceMonitor:
       enabled: true
       params:

--- a/kubernetes/apps/observability/victoria-logs/mcp/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/mcp/helmrelease.yaml
@@ -14,6 +14,11 @@ spec:
       entrypoint: http://victoria-logs.observability.svc.cluster.local:9428
     mcp:
       mode: http
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 10m
     podSecurityContext:
       runAsNonRoot: true
       runAsUser: 65534

--- a/kubernetes/apps/observability/victoria-metrics/mcp/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/mcp/helmrelease.yaml
@@ -15,6 +15,11 @@ spec:
       entrypoint: http://victoria-metrics.observability.svc.cluster.local:8428
     mcp:
       mode: http
+    resources:
+      limits:
+        memory: 1Gi
+      requests:
+        cpu: 10m
     podSecurityContext:
       runAsNonRoot: true
       runAsUser: 65534


### PR DESCRIPTION
## Summary
- add memory limits and 10m CPU requests for opentelemetry-operator, grafana-operator, and snmp-exporter-ups
- add memory limits and 10m CPU requests for victoria-logs-mcp and victoria-metrics-mcp
- size limits from 90-day container working-set history

## Historical basis
- grafana-operator: ~51Mi max -> 128Mi limit
- opentelemetry-operator: ~99Mi max -> 256Mi limit
- snmp-exporter-ups: ~50Mi max -> 128Mi limit
- victoria-logs-mcp: ~319Mi max, ~76Mi current -> 512Mi limit
- victoria-metrics-mcp: ~627Mi max, ~487Mi current -> 1Gi limit

## Validation
- flate build hr renders for affected HelmReleases confirmed resources land on containers
- flate test all --path kubernetes/flux/cluster --log-level error
- 305 passed, 0 skipped, 0 failed