### PR TITLE
chore: migrate pod securityContext to defaultPodOptions in app-template HelmReleases

### DIFF
--- a/kubernetes/apps/database/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/database/mosquitto/app/helmrelease.yaml
@@ -67,12 +67,12 @@ spec:
                 drop:
                   - "ALL"
               readOnlyRootFilesystem: true
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsGroup: 2000
-            runAsUser: 2000
-            fsGroup: 2000
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 2000
+        runAsUser: 2000
+        fsGroup: 2000
     persistence:
       config:
         type: configMap

--- a/kubernetes/apps/default/paperless/gotenberg/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless/gotenberg/helmrelease.yaml
@@ -56,13 +56,12 @@ spec:
               capabilities:
                 drop:
                   - "ALL"
-        pod:
-          automountServiceAccountToken: false
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
         strategy: RollingUpdate
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
     persistence:
       tmp:
         enabled: true

--- a/kubernetes/apps/default/paperless/tika/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless/tika/helmrelease.yaml
@@ -33,13 +33,12 @@ spec:
               capabilities:
                 drop:
                   - "ALL"
-        pod:
-          automountServiceAccountToken: false
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
         strategy: RollingUpdate
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
     persistence:
       tmp:
         enabled: true

--- a/kubernetes/apps/media/plex/auto-languages/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/auto-languages/helmrelease.yaml
@@ -64,12 +64,11 @@ spec:
                 drop:
                   - "ALL"
               readOnlyRootFilesystem: true
-        pod:
-          automountServiceAccountToken: false
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
     persistence:
       cache:
         type: emptyDir

--- a/kubernetes/apps/media/plex/imagemaid/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/imagemaid/helmrelease.yaml
@@ -47,22 +47,21 @@ spec:
                 drop:
                   - "ALL"
               readOnlyRootFilesystem: true
-        pod:
-          affinity:
-            podAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchExpressions:
-                      - key: app.kubernetes.io/name
-                        operator: In
-                        values:
-                          - plex
-                  topologyKey: kubernetes.io/hostname
-          automountServiceAccountToken: false
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
+    defaultPodOptions:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - plex
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
     persistence:
       config:
         type: emptyDir

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -56,24 +56,23 @@ spec:
                 drop:
                   - "ALL"
               readOnlyRootFilesystem: true
-        pod:
-          affinity:
-            nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - preference:
-                    matchExpressions:
-                      - key: kubernetes.io/hostname
-                        operator: In
-                        values:
-                          - wizone
-                  weight: 1
-          automountServiceAccountToken: false
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
-            fsGroup: 1000
-            fsGroupChangePolicy: OnRootMismatch
+    defaultPodOptions:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - wizone
+              weight: 1
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     configMaps:
       config:
         data:

--- a/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
@@ -61,12 +61,11 @@ spec:
                 drop:
                   - "ALL"
               readOnlyRootFilesystem: true
-        pod:
-          automountServiceAccountToken: false
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
     service:
       app:
         ports:


### PR DESCRIPTION
## Summary

- Migrates `pod.securityContext` (and other pod-level fields like `affinity`) from controller-scoped `pod:` blocks to top-level `defaultPodOptions` in 7 app-template HelmReleases
- Drops `automountServiceAccountToken: false` where present — this is the default in app-template

## Affected
- `database/mosquitto`
- `default/paperless/gotenberg`
- `default/paperless/tika`
- `media/plex/auto-languages`
- `media/plex/imagemaid`
- `media/qbittorrent`
- `observability/unpoller`