### PR TITLE
feat(observability): add drm-exporter for Intel iGPU metrics

### DIFF
--- a/kubernetes/apps/observability/drm-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/drm-exporter/app/helmrelease.yaml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app drm-exporter
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: drm-exporter
+  values:
+    fullnameOverride: *app
+    config:
+      logLevel: info
+      # Match the ServiceMonitor scrape interval so each scrape carries one
+      # full sampling window (avoids aliasing short engine-utilization spikes).
+      intervalSeconds: 10
+    # /dev/dri is injected by the Intel GPU DRA driver via CDI (a hostPath
+    # /dev/dri is cgroup-blocked for a non-privileged container). /sys stays
+    # mounted for frequency/memory/hwmon stats; no MSR path on Talos.
+    hostAccess:
+      devDri: ""
+      devCpu: ""
+    # Admin-access monitor claim: read-only visibility of every iGPU on the
+    # node, allocated All, not counted as consumed (never steals a workload VF).
+    # Requires the namespace label resource.kubernetes.io/admin-access: "true".
+    dra:
+      enabled: true
+      deviceClassName: gpu.intel.com
+      adminAccess: true
+      allocationMode: All
+    # Drop SYS_RAWIO (needs the msr module, absent on Talos); keep PERFMON for
+    # i915 engine-utilization sampling via the perf PMU.
+    securityContext:
+      capabilities:
+        drop:
+          - ALL
+        add:
+          - PERFMON
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 64Mi
+    monitoring:
+      serviceMonitor:
+        enabled: true
+        interval: 10s
+        relabelings:
+          - sourceLabels: [__meta_kubernetes_endpoint_node_name]
+            targetLabel: nodename
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          folder: observability
+          matchLabels:
+            dashboards: grafana

--- a/kubernetes/apps/observability/drm-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/drm-exporter/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/drm-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/drm-exporter/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: drm-exporter
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.2.1
+  url: oci://ghcr.io/home-operations/charts/drm-exporter
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token.actions.githubusercontent.com$"
+        subject: "^https://github.com/home-operations/drm-exporter.*$"

--- a/kubernetes/apps/observability/drm-exporter/ks.yaml
+++ b/kubernetes/apps/observability/drm-exporter/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app drm-exporter
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kube-prometheus-stack
+    - name: intel-gpu-resource-driver
+      namespace: kube-system
+  interval: 1h
+  path: ./kubernetes/apps/observability/drm-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -10,6 +10,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./blackbox-exporter/ks.yaml
+  - ./drm-exporter/ks.yaml
   - ./gatus/ks.yaml
   - ./grafana-mcp/ks.yaml
   - ./grafana-operator/ks.yaml

--- a/kubernetes/apps/observability/namespace.yaml
+++ b/kubernetes/apps/observability/namespace.yaml
@@ -5,3 +5,5 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"


### PR DESCRIPTION
## Summary

Adds [drm-exporter](https://github.com/home-operations/drm-exporter) (home-operations Helm chart `0.2.1`) to the `observability` namespace — a per-node DaemonSet exporting Intel iGPU telemetry (engine utilization, memory, frequency, power, thermals) to Prometheus via the kernel DRM interfaces.

## Design

- **DRA, not hostPath** — GPU access via a chart-rendered `ResourceClaimTemplate`: `adminAccess: true`, `allocationMode: All`, `deviceClassName: gpu.intel.com`. This is a **non-consuming monitor claim** — it reads every iGPU on the node without consuming it, so it never steals an SR-IOV VF from transcoding workloads (go2rtc, etc.). `/dev/dri` is CDI-injected by the Intel GPU DRA driver (a hostPath `/dev/dri` is cgroup-blocked for a non-privileged container).
- **Namespace label** — `adminAccess` requires `resource.kubernetes.io/admin-access: "true"` on the release namespace; added to `observability/namespace.yaml` (matches the existing `home`/`media`/`default` convention).
- **Talos hardening** — `SYS_RAWIO` dropped (no `msr` module on Talos); only `PERFMON` kept for i915 perf-PMU engine sampling. `devCpu`/`devDri` host mounts left empty.
- **cosign** — OCIRepository pins keyless verification (`issuer ^https://token.actions.githubusercontent.com$`, `subject ^https://github.com/home-operations/drm-exporter.*$`), matching the repo's `kromgo` pattern. Verified `cosign verify` passes against `0.2.1`.
- **Dashboard + metrics** — chart-native `GrafanaDashboard` (grafana-operator, `dashboards: grafana`, folder `observability`) and `ServiceMonitor`. Sampling and scrape aligned at 10s to avoid aliasing.
- **Scheduling** — every node has a single iGPU, so no GPU nodeSelector (matches go2rtc); DaemonSet runs cluster-wide. `dependsOn` kube-prometheus-stack (ServiceMonitor CRD) and intel-gpu-resource-driver (DRA driver).

## Validation

- `flate test all` → **308 passed, 0 failed**
- Render confirms: DaemonSet (PERFMON-only caps), ResourceClaimTemplate (adminAccess/All/gpu.intel.com), pod `resourceClaimTemplateName` injected, GrafanaDashboard, ServiceMonitor, Service, ServiceAccount.
- `cosign verify` against chart `0.2.1` passes with the pinned identity.
- Adversarial code review (Codex): no critical/high findings. Confirmed `DRAAdminAccess` is GA/on-by-default in k8s 1.36, control-plane scheduling allowed, cosign field shape valid.

## Note

The `admin-access` namespace label applies namespace-wide — any principal that can create a `ResourceClaim` in `observability` could request admin access. Accepted: it's the required DRA admin-access mechanism and matches existing repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)