### PR TITLE
feat(default): add flaresolverr

### DIFF
--- a/kubernetes/apps/default/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/flaresolverr/app/helmrelease.yaml
@@ -1,0 +1,100 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: flaresolverr
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: flaresolverr
+  values:
+    controllers:
+      flaresolverr:
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/flaresolverr/flaresolverr
+              tag: v3.5.0@sha256:139dfee1c6f89249c8d665d1333a42e8ec74ec0a86bc6bb1c8461e10d3a66a47
+            env:
+              TZ: America/New_York
+              LOG_LEVEL: info
+              PORT: &port 8191
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 50m
+              limits:
+                memory: 1Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - "ALL"
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    persistence:
+      config:
+        type: emptyDir
+        globalMounts:
+          - path: /config
+      chromium:
+        type: emptyDir
+        globalMounts:
+          - path: /app/.config
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      dev-shm:
+        type: emptyDir
+        advancedMounts:
+          flaresolverr:
+            app:
+              - path: /dev/shm
+        medium: Memory
+        sizeLimit: 256Mi
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/default/flaresolverr/app/kustomization.yaml
+++ b/kubernetes/apps/default/flaresolverr/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/flaresolverr/app/ocirepository.yaml
+++ b/kubernetes/apps/default/flaresolverr/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flaresolverr
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token.actions.githubusercontent.com$"
+        subject: "^https://github.com/bjw-s-labs/helm-charts.*$"

--- a/kubernetes/apps/default/flaresolverr/ks.yaml
+++ b/kubernetes/apps/default/flaresolverr/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app flaresolverr
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/default/flaresolverr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./actual/ks.yaml
   - ./atuin/ks.yaml
   - ./changedetection/ks.yaml
+  - ./flaresolverr/ks.yaml
   - ./it-tools/ks.yaml
   - ./maddy/ks.yaml
   - ./paperless/ks.yaml

--- a/kubernetes/apps/media/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/media/suwayomi/app/helmrelease.yaml
@@ -23,6 +23,8 @@ spec:
               BACKUP_INTERVAL: 0
               BIND_PORT: &port 80
               EXTENSION_REPOS: '["https://github.com/keiyoushi/extensions/tree/repo"]'
+              FLARESOLVERR_ENABLED: true
+              FLARESOLVERR_URL: http://flaresolverr.default.svc.cluster.local:8191
               TZ: America/Los_Angeles
               UPDATE_EXCLUDE_STARTED: false
               UPDATE_EXCLUDE_UNREAD: false


### PR DESCRIPTION
## Summary

Deploy [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) `v3.5.0` via app-template in the `default` namespace, and wire [Suwayomi](https://github.com/Suwayomi/Suwayomi-Server-docker) to it.

## FlareSolverr

Full securityContext, same posture as it-tools:

| Control | Value |
|---|---|
| `runAsNonRoot` | true (uid/gid 1000 — `/app` + `/config` owned by it) |
| `allowPrivilegeEscalation` | false |
| `readOnlyRootFilesystem` | true |
| capabilities | drop ALL (Chromium runs `--no-sandbox`) |

Writable `emptyDir` mounts: `/config`, `/app/.config` (chromium), `/tmp`, and Memory-backed `/dev/shm` (256Mi, Chrome shared mem). ClusterIP only on :8191, no HTTPRoute (internal API). Image digest-pinned.

## Suwayomi

Add env per [Suwayomi-Server-docker](https://github.com/Suwayomi/Suwayomi-Server-docker):

- `FLARESOLVERR_ENABLED: true`
- `FLARESOLVERR_URL: http://flaresolverr.default.svc.cluster.local:8191` (cross-namespace FQDN: suwayomi in `media`, flaresolverr in `default`)

## Notes

- `flate test all` → 311 passed, 0 failed.