### PR TITLE
feat(flux-system): add flux-operator-mcp

### DIFF
--- a/kubernetes/apps/flux-system/flux-operator-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator-mcp/app/helmrelease.yaml
@@ -11,3 +11,11 @@ spec:
     name: flux-operator-mcp
   values:
     transport: http
+    httpRoute:
+      enabled: true
+      hostnames:
+        - flux-operator-mcp.perryhuynh.com
+      parentRefs:
+        - name: envoy-internal
+          namespace: networking
+          sectionName: https

--- a/kubernetes/apps/flux-system/flux-operator-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator-mcp/app/helmrelease.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: flux-operator-mcp
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: flux-operator-mcp
+  values:
+    transport: http

--- a/kubernetes/apps/flux-system/flux-operator-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/flux-operator-mcp/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/flux-system/flux-operator-mcp/app/ocirepository.yaml
+++ b/kubernetes/apps/flux-system/flux-operator-mcp/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-operator-mcp
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.52.0
+  url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator-mcp
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token.actions.githubusercontent.com$"
+        subject: "^https://github.com/controlplaneio-fluxcd/charts.*$"

--- a/kubernetes/apps/flux-system/flux-operator-mcp/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator-mcp/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app flux-operator-mcp
+  namespace: &namespace flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: flux-operator
+      namespace: flux-system
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/flux-system/flux-operator-mcp/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/flux-system/kustomization.yaml
+++ b/kubernetes/apps/flux-system/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
   - ./namespace.yaml
   - ./flux-instance/ks.yaml
   - ./flux-operator/ks.yaml
+  - ./flux-operator-mcp/ks.yaml
   - ./konflate/ks.yaml


### PR DESCRIPTION
## Summary
- Deploy the Flux Operator MCP server (controlplaneio-fluxcd/charts, flux-operator-mcp 0.52.0) in flux-system
- HTTP transport (chart only supports sse/http, not mcp)
- OCIRepository cosign-verified against controlplaneio-fluxcd/charts OIDC identity
- Depends on flux-operator Kustomization

## Test plan
- [x] `flate test ks --path kubernetes/flux/cluster flux-operator-mcp` passes
- [x] `flate test all --path kubernetes/flux/cluster --base origin/main` passes (314/314)