### PR TITLE
fix(flux-operator-mcp): set readonly true

### DIFF
--- a/kubernetes/apps/flux-system/flux-operator-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator-mcp/app/helmrelease.yaml
@@ -11,6 +11,7 @@ spec:
     name: flux-operator-mcp
   values:
     transport: http
+    readonly: true
     httpRoute:
       enabled: true
       hostnames:


### PR DESCRIPTION
## Summary
- Set `readonly: true` on flux-operator-mcp, disabling MCP tools that can modify cluster state

## Test plan
- [x] `flate test ks --path kubernetes/flux/cluster flux-operator-mcp` passes