### PR TITLE
fix(flux-operator-mcp): allow gateway namespace through netpol

### DIFF
--- a/kubernetes/apps/flux-system/flux-operator-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator-mcp/app/helmrelease.yaml
@@ -12,6 +12,10 @@ spec:
   values:
     transport: http
     readonly: true
+    networkPolicy:
+      ingress:
+        namespaces:
+          - networking
     httpRoute:
       enabled: true
       hostnames:


### PR DESCRIPTION
## Problem

The flux-operator-mcp HTTPRoute was unreachable. The chart's NetworkPolicy (`networkPolicy.create: true`) only allows ingress from the `flux-system` namespace, but the `envoy-internal` gateway runs in the `networking` namespace — so gateway → MCP pod traffic on port 9090 was dropped.

## Fix

Add `networking` to `networkPolicy.ingress.namespaces` so the gateway can reach the MCP pod.

Rendered netpol now includes a second `namespaceSelector` for `networking`.