### PR TITLE
feat(observability): add reaprime-exporter

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - ./kube-prometheus-stack/ks.yaml
   - ./opentelemetry/ks.yaml
   - ./prometheus-adapter/ks.yaml
+  - ./reaprime-exporter/ks.yaml
   - ./silence-operator/ks.yaml
   - ./siren/ks.yaml
   - ./smartctl-exporter/ks.yaml

--- a/kubernetes/apps/observability/reaprime-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/reaprime-exporter/app/helmrelease.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app reaprime-exporter
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: reaprime-exporter
+  values:
+    fullnameOverride: *app
+    config:
+      reaprimeUrl: http://de1pro.internal:8080
+      logLevel: info
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 64Mi
+    monitoring:
+      serviceMonitor:
+        enabled: true
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          folder: observability
+          matchLabels:
+            dashboards: grafana

--- a/kubernetes/apps/observability/reaprime-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/reaprime-exporter/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/reaprime-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/reaprime-exporter/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: reaprime-exporter
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.2.1
+  url: oci://ghcr.io/perryhuynh/charts/decent-exporter
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token.actions.githubusercontent.com$"
+        subject: "^https://github.com/perryhuynh/reaprime-exporter/.github/workflows/release.yaml@.*$"

--- a/kubernetes/apps/observability/reaprime-exporter/ks.yaml
+++ b/kubernetes/apps/observability/reaprime-exporter/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app reaprime-exporter
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kube-prometheus-stack
+  interval: 1h
+  path: ./kubernetes/apps/observability/reaprime-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true


### PR DESCRIPTION
Deploys [reaprime-exporter](https://github.com/perryhuynh/reaprime-exporter) (chart `decent-exporter`) in the `observability` namespace.

## What

- Prometheus exporter for Reaprime-powered Decent espresso tablets
- Scrapes the de1pro tablet webserver at `http://de1pro.internal:8080`
- Chart `oci://ghcr.io/perryhuynh/charts/decent-exporter:0.2.1`, cosign keyless verified
- ServiceMonitor enabled; Grafana dashboards via grafana-operator (`observability` folder)

## Notes

- Uses chart `0.2.1` which fixes the image-repository mismatch ([#6](https://github.com/perryhuynh/reaprime-exporter/issues/6)); no `image.repository` override needed.

## Validation

`flate test all --base origin/main` → 317 passed, 0 failed. Rendered deployment pulls `ghcr.io/perryhuynh/reaprime-exporter@sha256:e2c6...` with `DECENT_EXPORTER_REAPRIME_URL=http://de1pro.internal:8080`.