### PR TITLE
feat(kube-system): add kubernetes mcp server

### DIFF
--- a/kubernetes/apps/kube-system/kubernetes-mcp-server/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/kubernetes-mcp-server/app/helmrelease.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app kubernetes-mcp-server
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  values:
+    image:
+      registry: quay.io
+      repository: containers/kubernetes_mcp_server
+      # renovate: datasource=docker depName=quay.io/containers/kubernetes_mcp_server
+      version: v0.0.62@sha256:bd7e9ff49b0941ff230508dfceb87162c4a2be67b180c28f5d1b204fc58fa2e9
+    extraArgs:
+      - --read-only
+    ingress:
+      enabled: false
+    httpRoute:
+      enabled: true
+      parentRefs:
+        - name: envoy-internal
+          namespace: networking
+          sectionName: https
+      hostnames:
+        - kubernetes-mcp-server.perryhuynh.com
+    rbac:
+      extraClusterRoleBindings:
+        - name: view
+          roleRef:
+            name: view
+            external: true
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 10m

--- a/kubernetes/apps/kube-system/kubernetes-mcp-server/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kubernetes-mcp-server/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/kube-system/kubernetes-mcp-server/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/kubernetes-mcp-server/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kubernetes-mcp-server
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.0
+  url: oci://ghcr.io/containers/charts/kubernetes-mcp-server

--- a/kubernetes/apps/kube-system/kubernetes-mcp-server/ks.yaml
+++ b/kubernetes/apps/kube-system/kubernetes-mcp-server/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kubernetes-mcp-server
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/kubernetes-mcp-server/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./descheduler/ks.yaml
   - ./fstrim/ks.yaml
   - ./intel-gpu-resource-driver/ks.yaml
+  - ./kubernetes-mcp-server/ks.yaml
   - ./ksgate/ks.yaml
   - ./metrics-server/ks.yaml
   - ./reloader/ks.yaml


### PR DESCRIPTION
## Summary
- deploy kubernetes-mcp-server in kube-system via Flux HelmRelease
- expose it through the envoy-internal HTTPS Gateway HTTPRoute
- run the server with --read-only and bind its ServiceAccount to the built-in view ClusterRole
- set memory limit to 256Mi and leave chart defaults for other requests

## Notes
- Upstream chart and image did not verify with cosign: cosign verify returned no signatures found for both ghcr.io/containers/charts/kubernetes-mcp-server:0.1.0 and quay.io/containers/kubernetes_mcp_server:v0.0.62, so Flux cosign verification is not configured.

## Validation
- flate test all --path kubernetes/flux/cluster --base origin/main