### PR TITLE
feat(networking): add UniFi Network MCP

### DIFF
--- a/kubernetes/apps/networking/kustomization.yaml
+++ b/kubernetes/apps/networking/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - ./external-dns/ks.yaml
   - ./multus/ks.yaml
   - ./tailscale-operator/ks.yaml
+  - ./unifi-network-mcp/ks.yaml

--- a/kubernetes/apps/networking/unifi-network-mcp/app/externalsecret.yaml
+++ b/kubernetes/apps/networking/unifi-network-mcp/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: unifi-network-mcp
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    deletionPolicy: Delete
+    template:
+      engineVersion: v2
+      data:
+        UNIFI_NETWORK_PASSWORD: "{{ .mcp_password }}"
+        UNIFI_NETWORK_USERNAME: "{{ .mcp_username }}"
+  dataFrom:
+    - extract:
+        key: unifi

--- a/kubernetes/apps/networking/unifi-network-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/unifi-network-mcp/app/helmrelease.yaml
@@ -1,0 +1,86 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app unifi-network-mcp
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  values:
+    controllers:
+      unifi-network-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/sirkirby/unifi-network-mcp
+              tag: 0.20.7@sha256:cbbae3060bf482c3fe6cb9c2f4f3dbc2e5e270f20c8ca4917f4c8ce4cc583835
+            env:
+              UNIFI_MCP_ALLOWED_HOSTS: unifi-network-mcp.perryhuynh.com
+              UNIFI_MCP_HTTP_ENABLED: true
+              UNIFI_MCP_HTTP_TRANSPORT: streamable-http
+              UNIFI_NETWORK_HOST: unifi.internal
+              UNIFI_NETWORK_VERIFY_SSL: false
+              UNIFI_POLICY_NETWORK_CREATE: false
+              UNIFI_POLICY_NETWORK_DELETE: false
+              UNIFI_POLICY_NETWORK_UPDATE: false
+            envFrom:
+              - secretRef:
+                  name: *app
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  tcpSocket:
+                    port: &port 3000
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              limits:
+                memory: 256Mi
+              requests:
+                cpu: 10m
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+    route:
+      app:
+        hostnames:
+          - unifi-network-mcp.perryhuynh.com
+        parentRefs:
+          - name: envoy-internal
+            namespace: networking
+            sectionName: https
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/networking/unifi-network-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/networking/unifi-network-mcp/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/networking/unifi-network-mcp/app/ocirepository.yaml
+++ b/kubernetes/apps/networking/unifi-network-mcp/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: unifi-network-mcp
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token.actions.githubusercontent.com$"
+        subject: "^https://github.com/bjw-s-labs/helm-charts.*$"

--- a/kubernetes/apps/networking/unifi-network-mcp/ks.yaml
+++ b/kubernetes/apps/networking/unifi-network-mcp/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app unifi-network-mcp
+  namespace: &namespace networking
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/networking/unifi-network-mcp/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true


### PR DESCRIPTION
## Summary

- deploy UniFi Network MCP in the networking namespace
- source view-only credentials from the unifi 1Password item keys mcp_username and mcp_password
- expose Streamable HTTP through the internal Gateway and disable create, update, and delete policies

## Validation

- flate test all --path kubernetes/flux/cluster (323 passed)
- focused HelmRelease render inspected

## Prerequisite

The unifi 1Password item must contain mcp_username and mcp_password.