### PR TITLE
feat(networking): add agentgateway MCP federation gateway

### DIFF
--- a/kubernetes/apps/networking/agentgateway/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/agentgateway/app/helmrelease.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: agentgateway
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: agentgateway
+  dependsOn:
+    - name: agentgateway-crds
+  values: {}

--- a/kubernetes/apps/networking/agentgateway/app/ocirepository.yaml
+++ b/kubernetes/apps/networking/agentgateway/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: agentgateway
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    # renovate: datasource=docker depName=ghcr.io/kgateway-dev/charts/agentgateway
+    tag: v2.3.0-main
+  url: oci://ghcr.io/kgateway-dev/charts/agentgateway

--- a/kubernetes/apps/networking/agentgateway/app/ocirepository.yaml
+++ b/kubernetes/apps/networking/agentgateway/app/ocirepository.yaml
@@ -12,4 +12,7 @@ spec:
   ref:
     # renovate: datasource=docker depName=ghcr.io/kgateway-dev/charts/agentgateway
     tag: v2.3.0-main
+    # chart is not cosign-signed and v2.3.0-main is a moving tag; pin by digest so a tag
+    # move cannot silently deploy unreviewed control-plane code (renovate tracks via the tag above)
+    digest: sha256:1aa951487cf5e99edee977abd4572483911e2f065a37e00aa919b42aacde700d
   url: oci://ghcr.io/kgateway-dev/charts/agentgateway

--- a/kubernetes/apps/networking/agentgateway/crds/helmrelease.yaml
+++ b/kubernetes/apps/networking/agentgateway/crds/helmrelease.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: agentgateway-crds
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: agentgateway-crds
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values: {}

--- a/kubernetes/apps/networking/agentgateway/crds/ocirepository.yaml
+++ b/kubernetes/apps/networking/agentgateway/crds/ocirepository.yaml
@@ -12,4 +12,7 @@ spec:
   ref:
     # renovate: datasource=docker depName=ghcr.io/kgateway-dev/charts/agentgateway-crds
     tag: v2.3.0-main
+    # chart is not cosign-signed and v2.3.0-main is a moving tag; pin by digest so a tag
+    # move cannot silently deploy unreviewed CRDs (renovate tracks via the tag above)
+    digest: sha256:ed7525734fa5f9ab9541c1358af355b8f8c836121c1aa8af01a578ab58297169
   url: oci://ghcr.io/kgateway-dev/charts/agentgateway-crds

--- a/kubernetes/apps/networking/agentgateway/crds/ocirepository.yaml
+++ b/kubernetes/apps/networking/agentgateway/crds/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: agentgateway-crds
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    # renovate: datasource=docker depName=ghcr.io/kgateway-dev/charts/agentgateway-crds
+    tag: v2.3.0-main
+  url: oci://ghcr.io/kgateway-dev/charts/agentgateway-crds

--- a/kubernetes/apps/networking/agentgateway/gateway/backend.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/backend.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/agentgateway.dev/agentgatewaybackend_v1alpha1.json
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: mcp
+spec:
+  mcp:
+    targets:
+      - name: kubernetes
+        static:
+          host: kubernetes-mcp-server.kube-system.svc.cluster.local
+          port: 8080
+          protocol: StreamableHTTP
+      - name: unifi
+        static:
+          host: unifi-network-mcp.networking.svc.cluster.local
+          port: 3000
+          protocol: StreamableHTTP
+      - name: flux
+        static:
+          host: flux-operator-mcp.flux-system.svc.cluster.local
+          port: 9090
+          protocol: StreamableHTTP
+      - name: grafana
+        static:
+          host: grafana-mcp.observability.svc.cluster.local
+          port: 8000
+          protocol: StreamableHTTP
+      - name: victoria-logs
+        static:
+          host: victoria-logs-mcp.observability.svc.cluster.local
+          port: 8080
+          protocol: StreamableHTTP
+      - name: victoria-metrics
+        static:
+          host: victoria-metrics-mcp.observability.svc.cluster.local
+          port: 8080
+          protocol: StreamableHTTP
+      - name: konflate
+        static:
+          host: konflate.flux-system.svc.cluster.local
+          port: 8080
+          protocol: StreamableHTTP

--- a/kubernetes/apps/networking/agentgateway/gateway/gateway.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/gateway.yaml
@@ -19,7 +19,7 @@ spec:
       hostname: mcp.perryhuynh.com
       allowedRoutes:
         namespaces:
-          from: All
+          from: Same
       tls:
         certificateRefs:
           - kind: Secret

--- a/kubernetes/apps/networking/agentgateway/gateway/gateway.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/gateway.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/gateway_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: agentgateway
+  annotations:
+    external-dns.alpha.kubernetes.io/target: &hostname internal.perryhuynh.com
+spec:
+  gatewayClassName: agentgateway
+  infrastructure:
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: *hostname
+      lbipam.cilium.io/ips: 192.168.20.202
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: mcp.perryhuynh.com
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: perryhuynh-com-production-tls

--- a/kubernetes/apps/networking/agentgateway/gateway/httproute.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/httproute.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mcp
+spec:
+  parentRefs:
+    - name: agentgateway
+      namespace: networking
+      sectionName: https
+  hostnames:
+    - mcp.perryhuynh.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mcp
+      backendRefs:
+        - name: mcp
+          group: agentgateway.dev
+          kind: AgentgatewayBackend

--- a/kubernetes/apps/networking/agentgateway/gateway/kustomization.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./gateway.yaml
+  - ./backend.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/networking/agentgateway/ks.yaml
+++ b/kubernetes/apps/networking/agentgateway/ks.yaml
@@ -1,0 +1,64 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app agentgateway-crds
+  namespace: &namespace networking
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/networking/agentgateway/crds
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app agentgateway
+  namespace: &namespace networking
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: agentgateway-crds
+  interval: 1h
+  path: ./kubernetes/apps/networking/agentgateway/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app agentgateway-gateway
+  namespace: &namespace networking
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: agentgateway
+  interval: 1h
+  path: ./kubernetes/apps/networking/agentgateway/gateway
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/networking/kustomization.yaml
+++ b/kubernetes/apps/networking/kustomization.yaml
@@ -9,6 +9,7 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./agentgateway/ks.yaml
   - ./certificates/ks.yaml
   - ./cloudflared/ks.yaml
   - ./echo-server/ks.yaml


### PR DESCRIPTION
## What

Stands up an [agentgateway](https://agentgateway.dev) data plane (kgateway-dev charts, `v2.3.0-main`) alongside Envoy Gateway, federating all 7 in-cluster MCP servers behind one endpoint: `https://mcp.perryhuynh.com/mcp`.

- `agentgateway-crds` + `agentgateway` HelmReleases (control-plane only; registers the `agentgateway` GatewayClass at runtime), ordered Kustomizations crds → app → gateway.
- `Gateway` on a dedicated cilium internal LB IP (`192.168.20.202`), HTTPS at `mcp.perryhuynh.com`.
- `AgentgatewayBackend` federating 7 MCP Services via static streamable-http targets: kubernetes, unifi, flux, grafana, victoria-logs, victoria-metrics, konflate.
- `HTTPRoute` `/mcp` → the backend. Tools surface prefixed per target (`unifi_*`, `kubernetes_*`, …).

## Validation

`flate test all --path kubernetes/flux/cluster --base origin/main` → **330 passed** (offline render only; no live cluster).

## Decisions / review

- **No auth (intentional)** — internal-only (cilium internal LB + internal DNS), matching the existing per-app MCP routes which are also unauthenticated. Adversarial review flagged this; accepted for the homelab.
- Adversarial review fixes applied: chart OCIRepositories **digest-pinned** (chart is unsigned, `v2.3.0-main` is a moving tag); listener `allowedRoutes.namespaces.from: Same` (only the in-namespace `mcp` route attaches).

## NOT in this PR

- **VictoriaTraces / tracing** — dropped per decision; no trace backend or producer.
- **Cutover** — the 7 per-app MCP hostnames + routes are untouched and stay live in parallel. Retiring them (and updating `UNIFI_MCP_ALLOWED_HOSTS` for the agentgateway upstream Host) is a **follow-up PR after live verification**.

## Live verification needed after merge (Flux deploys on merge; could not be checked offline)

- [ ] `agentgateway` GatewayClass `Accepted`, controller pod `Running`
- [ ] `192.168.20.202` free + assigned; `Gateway` `Programmed`; `dig mcp.perryhuynh.com` resolves
- [ ] LB-IP via `infrastructure.annotations` honored by agentgateway (else move to `AgentgatewayParameters.spec.service`)
- [ ] `perryhuynh-com-production-tls` readable from `networking`
- [ ] MCP `tools/list` against `mcp.perryhuynh.com/mcp` returns all 7 targets; spot-check one read-only call each