### PR TITLE
fix(networking): move agentgateway LB IP to 192.168.20.67

### DIFF
--- a/kubernetes/apps/networking/agentgateway/gateway/gateway.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/gateway.yaml
@@ -11,7 +11,7 @@ spec:
   infrastructure:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: *hostname
-      lbipam.cilium.io/ips: 192.168.20.202
+      lbipam.cilium.io/ips: 192.168.20.67
   listeners:
     - name: https
       protocol: HTTPS


### PR DESCRIPTION
Live verification of #7103 found the agentgateway LB Service stuck at `EXTERNAL-IP <pending>`: cilium rejected `192.168.20.202` with `already allocated to another service` — `.202` belongs to `maddy-smtp` (default ns). The `.202`-free assumption shipped unverified.

`192.168.20.67` is free and in-pool (cilium pool covers `192.168.20.0/24`).

flate: 2 passed (changed-only). After merge, cilium should assign `.67` to the `agentgateway` Service and the Gateway endpoint comes up at `mcp.perryhuynh.com`.