### PR TITLE
fix(networking): publish agentgateway to unifi

### DIFF
--- a/kubernetes/apps/networking/agentgateway/gateway/gateway.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/gateway.yaml
@@ -4,6 +4,8 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: agentgateway
+  labels:
+    external-dns.home.arpa/provider: unifi
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname internal.perryhuynh.com
 spec:

--- a/kubernetes/apps/networking/envoy-gateway/config/gateway.yaml
+++ b/kubernetes/apps/networking/envoy-gateway/config/gateway.yaml
@@ -35,6 +35,8 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: envoy-internal
+  labels:
+    external-dns.home.arpa/provider: unifi
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname internal.perryhuynh.com
 spec:

--- a/kubernetes/apps/networking/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/unifi/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
           initialDelaySeconds: 10
           timeoutSeconds: 5
     extraArgs:
-      - --gateway-name=envoy-internal
+      - --gateway-label-filter=external-dns.home.arpa/provider=unifi
     triggerLoopOnEvent: true
     policy: sync
     sources:


### PR DESCRIPTION
## Summary
- select UniFi-managed Gateways with a shared label
- include both envoy-internal and agentgateway
- keep envoy-external excluded

## Validation
- flate test all --path kubernetes/flux/cluster --base origin/main