### PR TITLE
fix(networking): isolate agentgateway DNS

### DIFF
--- a/kubernetes/apps/networking/agentgateway/gateway/gateway.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/gateway.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     external-dns.home.arpa/provider: unifi
   annotations:
-    external-dns.alpha.kubernetes.io/target: &hostname internal.perryhuynh.com
+    external-dns.alpha.kubernetes.io/target: &hostname agentgateway.internal
 spec:
   gatewayClassName: agentgateway
   infrastructure:


### PR DESCRIPTION
## Summary
- give agentgateway a dedicated agentgateway.internal DNS target
- prevent internal.perryhuynh.com from resolving to both Envoy and agentgateway
- route mcp.perryhuynh.com only to 192.168.20.67

## Validation
- flate test all --path kubernetes/flux/cluster --base origin/main