### PR TITLE
fix(networking): rename MCP gateway

### DIFF
--- a/kubernetes/apps/networking/agentgateway/gateway/gateway.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/gateway.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: agentgateway
+  name: mcp
   labels:
     external-dns.home.arpa/provider: unifi
   annotations:

--- a/kubernetes/apps/networking/agentgateway/gateway/httproute.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mcp
 spec:
   parentRefs:
-    - name: agentgateway
+    - name: mcp
       namespace: networking
       sectionName: https
   hostnames:


### PR DESCRIPTION
## Summary
- rename the Gateway from agentgateway to mcp
- update the HTTPRoute parent reference
- avoid collision with the agentgateway controller Deployment

The collision prevented creation of the dataplane Deployment, leaving the LoadBalancer Service without endpoints.

## Validation
- flate test all --path kubernetes/flux/cluster --base origin/main