### PR TITLE
fix(networking): finalize MCP federation

### DIFF
--- a/kubernetes/apps/flux-system/flux-operator-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator-mcp/app/helmrelease.yaml
@@ -16,11 +16,3 @@ spec:
       ingress:
         namespaces:
           - networking
-    httpRoute:
-      enabled: true
-      hostnames:
-        - flux-operator-mcp.perryhuynh.com
-      parentRefs:
-        - name: envoy-internal
-          namespace: networking
-          sectionName: https

--- a/kubernetes/apps/kube-system/kubernetes-mcp-server/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/kubernetes-mcp-server/app/helmrelease.yaml
@@ -19,14 +19,6 @@ spec:
       - --read-only
     ingress:
       enabled: false
-    httpRoute:
-      enabled: true
-      parentRefs:
-        - name: envoy-internal
-          namespace: networking
-          sectionName: https
-      hostnames:
-        - kubernetes-mcp-server.perryhuynh.com
     rbac:
       extraClusterRoleBindings:
         - name: view

--- a/kubernetes/apps/networking/unifi-network-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/unifi-network-mcp/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
               repository: ghcr.io/sirkirby/unifi-network-mcp
               tag: 0.20.7@sha256:cbbae3060bf482c3fe6cb9c2f4f3dbc2e5e270f20c8ca4917f4c8ce4cc583835
             env:
-              UNIFI_MCP_ALLOWED_HOSTS: unifi-network-mcp.perryhuynh.com
+              UNIFI_MCP_ALLOWED_HOSTS: unifi-network-mcp.networking.svc.cluster.local
               UNIFI_MCP_HTTP_ENABLED: true
               UNIFI_MCP_HTTP_TRANSPORT: streamable-http
               UNIFI_NETWORK_HOST: unifi.internal
@@ -71,14 +71,6 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
-    route:
-      app:
-        hostnames:
-          - unifi-network-mcp.perryhuynh.com
-        parentRefs:
-          - name: envoy-internal
-            namespace: networking
-            sectionName: https
     service:
       app:
         ports:

--- a/kubernetes/apps/observability/grafana-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana-mcp/app/helmrelease.yaml
@@ -29,12 +29,3 @@ spec:
         memory: 128Mi
       requests:
         cpu: 10m
-    route:
-      main:
-        enabled: true
-        hostnames:
-          - grafana-mcp.perryhuynh.com
-        parentRefs:
-          - name: envoy-internal
-            namespace: networking
-            sectionName: https

--- a/kubernetes/apps/observability/victoria-logs/mcp/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/mcp/helmrelease.yaml
@@ -28,10 +28,3 @@ spec:
       capabilities:
         drop: ["ALL"]
       readOnlyRootFilesystem: true
-    route:
-      enabled: true
-      parentRefs:
-        - name: envoy-internal
-          namespace: networking
-      hostnames:
-        - victoria-logs-mcp.perryhuynh.com

--- a/kubernetes/apps/observability/victoria-metrics/mcp/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/mcp/helmrelease.yaml
@@ -29,10 +29,3 @@ spec:
       capabilities:
         drop: ["ALL"]
       readOnlyRootFilesystem: true
-    route:
-      enabled: true
-      parentRefs:
-        - name: envoy-internal
-          namespace: networking
-      hostnames:
-        - victoria-metrics-mcp.perryhuynh.com


### PR DESCRIPTION
Allow agentgateway to initialize the UniFi backend through its cluster-local hostname and remove superseded direct MCP routes.