### PR TITLE
ci(renovate): pin tool version to the action, drop version input

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -24,10 +24,6 @@ on:
           - debug
           - info
         type: choice
-      version:
-        description: Renovate version
-        default: latest
-        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
@@ -68,4 +64,3 @@ jobs:
           RENOVATE_PLATFORM_COMMIT: true
         with:
           token: "${{ steps.app-token.outputs.token }}"
-          renovate-version: "${{ inputs.version || 'latest' }}"


### PR DESCRIPTION
## What

Remove the `renovate-version: latest` param from the Run Renovate step and the now-unused `version` `workflow_dispatch` input.

## Why

`renovatebot/github-action` is already SHA-pinned (`@6d859fc… # v46.1.16`) and ships a matching Renovate release, which Renovate keeps current via the action bump (e.g. #7111). The `renovate-version: latest` param was a redundant second source that could drift from the pinned action. Dropping it makes the action SHA the single source of truth for the Renovate version.

## Notes

- No behavior change for scheduled/push runs.
- `workflow_dispatch` still exposes `dryRun` and `logLevel`.