### PR TITLE
feat(scrypted): restore for ring, no gpu, no service lb

### DIFF
--- a/kubernetes/apps/home/go2rtc/app/resources/go2rtc.yaml
+++ b/kubernetes/apps/home/go2rtc/app/resources/go2rtc.yaml
@@ -14,25 +14,9 @@ webrtc:
 streams:
   g6_instant:
     - "rtspx://192.168.1.1:7441/3zyX0mU98PANTSgU"
-  driveway:
-    - "ring:?camera_id=${RING_DRIVEWAY_CAMERA_ID}&device_id=${RING_DRIVEWAY_DEVICE_ID}&refresh_token=${RING_REFRESH_TOKEN}"
-    - "ring:?camera_id=${RING_DRIVEWAY_CAMERA_ID}&device_id=${RING_DRIVEWAY_DEVICE_ID}&refresh_token=${RING_REFRESH_TOKEN}&snapshot"
-  front_door:
-    - "ring:?camera_id=${RING_FRONT_DOOR_CAMERA_ID}&device_id=${RING_FRONT_DOOR_DEVICE_ID}&refresh_token=${RING_REFRESH_TOKEN}"
-    - "ring:?camera_id=${RING_FRONT_DOOR_CAMERA_ID}&device_id=${RING_FRONT_DOOR_DEVICE_ID}&refresh_token=${RING_REFRESH_TOKEN}&snapshot"
 homekit:
   g6_instant:
     name: g6_instant
-    pairings:
-      - "client_id=${GO2RTC_HOMEKIT_CLIENT_ID_0}&client_public=${GO2RTC_HOMEKIT_CLIENT_PUBLIC_0}&permissions=0"
-      - "client_id=${GO2RTC_HOMEKIT_CLIENT_ID_1}&client_public=${GO2RTC_HOMEKIT_CLIENT_PUBLIC_1}&permissions=1"
-  driveway:
-    name: driveway
-    pairings:
-      - "client_id=${GO2RTC_HOMEKIT_CLIENT_ID_0}&client_public=${GO2RTC_HOMEKIT_CLIENT_PUBLIC_0}&permissions=0"
-      - "client_id=${GO2RTC_HOMEKIT_CLIENT_ID_1}&client_public=${GO2RTC_HOMEKIT_CLIENT_PUBLIC_1}&permissions=1"
-  front_door:
-    name: front door
     pairings:
       - "client_id=${GO2RTC_HOMEKIT_CLIENT_ID_0}&client_public=${GO2RTC_HOMEKIT_CLIENT_PUBLIC_0}&permissions=0"
       - "client_id=${GO2RTC_HOMEKIT_CLIENT_ID_1}&client_public=${GO2RTC_HOMEKIT_CLIENT_PUBLIC_1}&permissions=1"

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
   - ./namespace.yaml
   - ./go2rtc/ks.yaml
   - ./home-assistant/ks.yaml
+  - ./scrypted/ks.yaml
   - ./teslamate/ks.yaml

--- a/kubernetes/apps/home/scrypted/app/helmrelease.yaml
+++ b/kubernetes/apps/home/scrypted/app/helmrelease.yaml
@@ -1,0 +1,100 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app scrypted
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: scrypted
+  values:
+    controllers:
+      scrypted:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            env:
+              SCRYPTED_INSECURE_PORT: &port 80
+            image:
+              repository: ghcr.io/koush/scrypted
+              tag: v0.144.1-noble-lite@sha256:97c6f8162f3cd59240fa742da5ee39bc0f4978c49fa8f1ad35e259fa8103a171
+            command:
+              - "npm"
+            args:
+              - "--prefix"
+              - "/server"
+              - "exec"
+              - "scrypted-serve"
+            resources:
+              limits:
+                memory: 8Gi
+              requests:
+                cpu: 100m
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - "ALL"
+              readOnlyRootFilesystem: true
+    defaultPodOptions:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |
+          [{
+            "name": "iot",
+            "namespace": "networking",
+            "ips": ["192.168.50.4/24"],
+            "mac": "a6:42:05:ea:fc:5b"
+          }]
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    persistence:
+      config:
+        existingClaim: scrypted
+        globalMounts:
+          - path: /server/volume
+      plugins:
+        existingClaim: scrypted-plugins
+        globalMounts:
+          - path: /server/volume/plugins
+      recs:
+        type: nfs
+        path: /mnt/tank/media
+        server: nas.home.arpa
+        globalMounts:
+          - path: /recs
+            subPath: scrypted
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          scrypted:
+            app:
+              - path: /.cache
+                subPath: cache
+              - path: /home/ubuntu/.npm
+                subPath: npm
+              - path: /tmp
+                subPath: tmp
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.perryhuynh.com"
+        parentRefs:
+          - name: envoy-internal
+            namespace: networking
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/home/scrypted/app/kustomization.yaml
+++ b/kubernetes/apps/home/scrypted/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/home/scrypted/app/ocirepository.yaml
+++ b/kubernetes/apps/home/scrypted/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: scrypted
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token.actions.githubusercontent.com$"
+        subject: "^https://github.com/bjw-s-labs/helm-charts.*$"

--- a/kubernetes/apps/home/scrypted/app/pvc.yaml
+++ b/kubernetes/apps/home/scrypted/app/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: scrypted-plugins
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/home/scrypted/ks.yaml
+++ b/kubernetes/apps/home/scrypted/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app scrypted
+  namespace: &namespace home
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: multus-networks
+      namespace: networking
+  interval: 1h
+  path: ./kubernetes/apps/home/scrypted/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true


### PR DESCRIPTION
## What

Restore scrypted (removed in #5828, reverted in #7030) to bridge **Ring** cameras (live + HKSV) into HomeKit. Scrypted takes over the Ring streams from go2rtc; go2rtc keeps only the Unifi `g6_instant` stream.

## Why the revert (#7030) is fixed

#7029 wouldn't schedule: it had a `NotIn wizone` node-affinity **and** requested an exclusive Intel GPU via DRA, but the only GPU on an allowed node was already held. Each `gpu.intel.com` device is single-allocation (no `allowMultipleAllocations`); `drm-exporter` uses non-reserving `adminAccess`, the real consumers (pinchflat/plex/go2rtc) each take a whole GPU.

Resolved by dropping the GPU entirely — Ring delivers H.264 and the cam count is low enough that HomeKit profile transcode runs fine on CPU. No claim, no affinity, schedules anywhere.

## Changes

- **scrypted** (`kubernetes/apps/home/scrypted/`):
  - Upstream `ghcr.io/koush/scrypted` **noble-lite** image (no vendor GPU media drivers, since transcode is CPU-only), custom entrypoint (`npm exec scrypted-serve`) bypassing the s6 `/init` → rootless (uid 1000, `readOnlyRootFilesystem`, all caps dropped).
  - `iot` multus network `192.168.50.4/24`; **no LoadBalancer** (ClusterIP only) — HomeKit/rebroadcast over the pod's iot IP.
  - **No GPU/DRA** — dropped inline ResourceClaimTemplate, claim, `intel-gpu-resource-driver` dependsOn, and the `wizone` affinity exclusion.
  - volsync config PVC + `scrypted-plugins` PVC, NFS `recs` mount, cosign-verified app-template OCIRepository.
- **go2rtc**: removed `driveway`/`front_door` Ring streams + HomeKit bridges; kept `g6_instant`.

## Follow-ups (runtime, not manifest)

- Ring auth via scrypted web UI (its own plugin); `RING_*` in go2rtc secret now unused.
- Re-pair Ring cameras in Home app via scrypted's HomeKit plugin.

## Verification

`flate test all --path kubernetes/flux/cluster --base origin/main` → **335 passed, 0 failed**.