### PR TITLE
fix(konflate): block /mcp on external httproute

### DIFF
--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -27,6 +27,17 @@ spec:
           namespace: networking
       hostnames:
         - "{{ .Release.Name }}.perryhuynh.com"
+      additionalRules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /mcp
+          filters:
+            - type: ExtensionRef
+              extensionRef:
+                group: gateway.envoyproxy.io
+                kind: HTTPRouteFilter
+                name: konflate-mcp-block
     monitoring:
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/flux-system/konflate/app/httproutefilter.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/httproutefilter.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/httproutefilter_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: HTTPRouteFilter
+metadata:
+  name: konflate-mcp-block
+spec:
+  directResponse:
+    statusCode: 404

--- a/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproutefilter.yaml
   - ./ocirepository.yaml


### PR DESCRIPTION
## Summary
- Konflate's public HTTPRoute (`konflate.perryhuynh.com`) routed every path to the backend, including `/mcp`.
- Adds an `additionalRules` entry matching `PathPrefix /mcp` with an Envoy Gateway `HTTPRouteFilter` direct-response 404, taking precedence over the default `/` rule via Gateway API path-match specificity.
- Internal MCP federation (agentgateway -> konflate.flux-system.svc.cluster.local) is unaffected — that path doesn't go through this external route.

## Test plan
- [x] `flate test all --path kubernetes/flux/cluster --base origin/main`
- [x] `flate build hr konflate --namespace flux-system` — confirmed rendered HTTPRoute has `/mcp` rule (ExtensionRef -> HTTPRouteFilter) ahead of default backend rule
- [ ] After merge, verify `curl -I https://konflate.perryhuynh.com/mcp` returns 404 and UI paths still work