### PR TITLE
fix(gatus): expect 404 for flux-webhook after cloudflare bot rule change

### DIFF
--- a/kubernetes/apps/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/config.yaml
@@ -22,6 +22,6 @@ endpoints:
     client:
       dns-resolver: tcp://1.1.1.1:53
     conditions:
-      - "[STATUS] == 403"
+      - "[STATUS] == 404"
     ui:
       hide-conditions: true


### PR DESCRIPTION
## Summary
- `flux-webhook.perryhuynh.com` previously returned **403** to the gatus probe because Cloudflare Super Bot Fight Mode blocked automated requests.
- A WAF custom rule (Skip → Super Bot Fight Mode, scoped to the webhook POST endpoints) is now live, so the probe reaches the flux notification-controller receiver, which returns **404** for the unmatched root path.
- Updates the gatus endpoint condition `[STATUS] == 403` → `[STATUS] == 404`.

The 404 still validates the full path is healthy: Cloudflare → tunnel → envoy → notification-controller.

## Test plan
- [x] `curl -s -o /dev/null -w '%{http_code}' https://flux-webhook.perryhuynh.com` → `404` (stable across samples)
- [x] `flate test all --path kubernetes/flux/cluster --base origin/main`