### PR TITLE
feat(omni-tools): add omni-tools deployment

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -15,5 +15,6 @@ resources:
   - ./flaresolverr/ks.yaml
   - ./it-tools/ks.yaml
   - ./maddy/ks.yaml
+  - ./omni-tools/ks.yaml
   - ./paperless/ks.yaml
   - ./thelounge/ks.yaml

--- a/kubernetes/apps/default/omni-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/default/omni-tools/app/helmrelease.yaml
@@ -1,0 +1,78 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: omni-tools
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: omni-tools
+  values:
+    controllers:
+      omni-tools:
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/perryhuynh/omni-tools
+              tag: 0.6.0@sha256:36d0e7e49112aff03d14f1138693de191397d61619fd3130c3b9a1b468e9dfe2
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 8080
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              limits:
+                memory: 256Mi
+              requests:
+                cpu: 10m
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - "ALL"
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.perryhuynh.com"
+        parentRefs:
+          - name: envoy-internal
+            namespace: networking
+            sectionName: https
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/default/omni-tools/app/kustomization.yaml
+++ b/kubernetes/apps/default/omni-tools/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/omni-tools/app/ocirepository.yaml
+++ b/kubernetes/apps/default/omni-tools/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: omni-tools
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token.actions.githubusercontent.com$"
+        subject: "^https://github.com/bjw-s-labs/helm-charts.*$"

--- a/kubernetes/apps/default/omni-tools/ks.yaml
+++ b/kubernetes/apps/default/omni-tools/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app omni-tools
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/default/omni-tools/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true


### PR DESCRIPTION
Adds omni-tools (self-hosted web toolbox, https://github.com/iib0011/omni-tools) deployment mirroring the it-tools layout.

- Image `ghcr.io/perryhuynh/omni-tools:0.6.0` from perryhuynh/containers
- app-template 5.0.1 chart, port 8080, route `omni-tools.perryhuynh.com` via envoy-internal
- Caddy static file server runs as `nobody` with readOnlyRootFilesystem; tmp emptyDir mounted at `/tmp` for XDG dirs

`flate test all` passes.