### PR TITLE
feat(observability): add mqtt-exporter scoped to de1

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - ./karma/ks.yaml
   - ./kromgo/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
+  - ./mqtt-exporter/ks.yaml
   - ./opentelemetry/ks.yaml
   - ./prometheus-adapter/ks.yaml
   - ./silence-operator/ks.yaml

--- a/kubernetes/apps/observability/mqtt-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mqtt-exporter/app/helmrelease.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app mqtt-exporter
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: mqtt-exporter
+  values:
+    controllers:
+      mqtt-exporter:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/kpetremann/mqtt-exporter
+              tag: 1.12.1@sha256:dca3255f35310f6ceb80ed1de94eebd1fe9def7aacaec4107fe37cdaa9eb3be0
+            env:
+              MQTT_ADDRESS: mosquitto.database.svc.cluster.local
+              MQTT_PORT: "1883"
+              # Scope the exporter to the Decent espresso machine; de1/state is
+              # a JSON payload that mqtt-exporter flattens into numeric metrics.
+              TOPIC: de1/#
+              PROMETHEUS_PORT: &port "9000"
+              LOG_LEVEL: INFO
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  periodSeconds: 30
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  periodSeconds: 30
+                  failureThreshold: 5
+            resources:
+              limits:
+                memory: 64Mi
+              requests:
+                cpu: 10m
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - "ALL"
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+    service:
+      app:
+        ports:
+          metrics:
+            port: 9000

--- a/kubernetes/apps/observability/mqtt-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/mqtt-exporter/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/observability/mqtt-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/mqtt-exporter/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mqtt-exporter
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token.actions.githubusercontent.com$"
+        subject: "^https://github.com/bjw-s-labs/helm-charts.*$"

--- a/kubernetes/apps/observability/mqtt-exporter/app/servicemonitor.yaml
+++ b/kubernetes/apps/observability/mqtt-exporter/app/servicemonitor.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mqtt-exporter
+spec:
+  endpoints:
+    - port: metrics
+      path: /metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mqtt-exporter

--- a/kubernetes/apps/observability/mqtt-exporter/ks.yaml
+++ b/kubernetes/apps/observability/mqtt-exporter/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mqtt-exporter
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kube-prometheus-stack
+    - name: mosquitto
+      namespace: database
+  interval: 1h
+  path: ./kubernetes/apps/observability/mqtt-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true


### PR DESCRIPTION
## What

Deploy [kpetremann/mqtt-exporter](https://github.com/kpetremann/mqtt-exporter) `1.12.1` under `observability`, filtered to `TOPIC: de1/#`.

Discovery against the live broker (`mosquitto.database.svc:1883`, anonymous) showed three publishers: `teslamate/cars/1/*` (65 topics), `de1/state` (JSON), `homeassistant/.../config` + healthcheck noise. This scopes the exporter to the Decent espresso machine only.

## Details

- **app-template 5.0.1** (cosign-verified), image pinned by digest.
- `TOPIC: de1/#` — mqtt-exporter flattens the `de1/state` JSON payload into numeric series (`head_temperature`, `mix_temperature`, `steam_heater_temperature`, `espresso_count`, `steaming_count`, `water_level_ml/mm`).
- Anonymous connect (broker has `allow_anonymous true`); no secret needed.
- **ServiceMonitor** on the Service's named `metrics` port (app-template names the Service port, not the container port, so PodMonitor `port: metrics` would not match).
- nonroot, readOnlyRootFS, drop ALL caps; 64Mi limit.
- `dependsOn`: `kube-prometheus-stack` (CRD) + `mosquitto`.

## Validation

`flate test all --path kubernetes/flux/cluster --base origin/main` → 333 passed.