### PR TITLE
fix(observability): use MQTT_TOPIC env for mqtt-exporter filter

### DIFF
--- a/kubernetes/apps/observability/mqtt-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mqtt-exporter/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
               MQTT_PORT: "1883"
               # Scope the exporter to the Decent espresso machine; de1/state is
               # a JSON payload that mqtt-exporter flattens into numeric metrics.
-              TOPIC: de1/#
+              MQTT_TOPIC: de1/#
               PROMETHEUS_PORT: &port 9000
               LOG_LEVEL: INFO
             probes:


### PR DESCRIPTION
## Problem

After #7159 merged, the exporter was scraping **everything** — teslamate (65 topics) and homeassistant config blobs — not just de1. Pod logs showed `mqtt_battery_level`, `mqtt_tpms_*`, `mqtt_odometer`, etc.

Root cause: kpetremann/mqtt-exporter reads the topic filter from **`MQTT_TOPIC`**, not `TOPIC`. The wrong var name was silently ignored, falling back to the default `#`.

Secondary issue this exposed: metrics are emitted with no topic label (`labels=()`), so flat names collide across publishers — e.g. `de1/state` and `teslamate/.../state` both collapse to `mqtt_state` and overwrite each other. Filtering to a single publisher avoids this.

## Fix

`TOPIC` → `MQTT_TOPIC: de1/#`.

## Validation

`flate test all --base origin/main` → 4 passed, 49 skipped.
Will confirm post-merge that logs only create `de1`-derived metrics.