### PR TITLE
fix(observability): relabel DE1 steam_state as Steam Heater

### DIFF
--- a/kubernetes/apps/observability/mqtt-exporter/app/resources/dashboard.json
+++ b/kubernetes/apps/observability/mqtt-exporter/app/resources/dashboard.json
@@ -92,7 +92,7 @@
         "defaults": {
           "color": { "mode": "thresholds" },
           "mappings": [
-            { "options": { "0": { "color": "text", "index": 1, "text": "Off" }, "1": { "color": "orange", "index": 0, "text": "Steaming" } }, "type": "value" }
+            { "options": { "0": { "color": "text", "index": 1, "text": "Off" }, "1": { "color": "orange", "index": 0, "text": "On" } }, "type": "value" }
           ],
           "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null }, { "color": "orange", "value": 1 } ] }
         },
@@ -112,7 +112,7 @@
       "targets": [
         { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max(mqtt_steam_state{topic=\"de1_state\"})", "legendFormat": "Steam", "refId": "A" }
       ],
-      "title": "Steam State",
+      "title": "Steam Heater",
       "type": "stat"
     },
     {
@@ -335,7 +335,7 @@
       "targets": [
         { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max(mqtt_online{topic=\"de1_state\"})", "legendFormat": "Online", "refId": "A" },
         { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max(mqtt_wake_state{topic=\"de1_state\"})", "legendFormat": "Awake", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max(mqtt_steam_state{topic=\"de1_state\"})", "legendFormat": "Steaming", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max(mqtt_steam_state{topic=\"de1_state\"})", "legendFormat": "Steam heater", "refId": "C" },
         { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max(mqtt_scale_connected{topic=\"de1_state\"})", "legendFormat": "Scale connected", "refId": "D" }
       ],
       "title": "Machine States",


### PR DESCRIPTION
## Problem

Dashboard showed "Steaming" whenever `steam_state == 1`, but checking the live broker the machine was just **heating at idle**:

```
"state": "Idle", "substate": "ready", "steam_state": true, "steam_mode": "On"
```

`steam_state`/`steam_mode` track the **steam boiler being powered on** (normal for an awake machine), not active milk steaming. True steaming is `state == "Steam"` — a string field mqtt-exporter drops (non-numeric), so it isn't available as a metric.

## Fix

- Stat panel title `Steam State` → `Steam Heater`; value mapping `1 → On` (was `Steaming`).
- Machine States timeseries legend `Steaming` → `Steam heater`.

## Follow-up (not in this PR)

To get a real machine-state panel (Idle/Espresso/Steam/Sleep), set `STATE_VALUES` on the exporter to map the `state` string to numbers. Can do if wanted.

## Validation

`flate test all --base origin/main` → 4 passed, 49 skipped. JSON validated.