### PR TITLE
fix(teslamate): remove duplicate password field causing substitution error

### DIFF
--- a/kubernetes/apps/home/teslamate/app/grafanadatasource.yaml
+++ b/kubernetes/apps/home/teslamate/app/grafanadatasource.yaml
@@ -31,5 +31,3 @@ spec:
       connMaxLifetime: 14400
       postgresVersion: 1600
       timescaledb: false
-    secureJsonData:
-      password: "${DATABASE_PASS}"


### PR DESCRIPTION
## Summary
- `GrafanaDatasource` set `secureJsonData.password` twice: via `valuesFrom.secretKeyRef` AND as literal `"${DATABASE_PASS}"`
- literal form triggered Flux postBuild substitution error (no such cluster var)
- removed dupe; `valuesFrom` already wires secret correctly

## Test plan
- [x] `flate test all --path kubernetes/flux/cluster --base origin/main` passes