### PR TITLE
feat(networking): expose legacy SSE endpoint on MCP gateway

### DIFF
--- a/kubernetes/apps/networking/agentgateway/gateway/httproute.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/httproute.yaml
@@ -16,6 +16,9 @@ spec:
         - path:
             type: PathPrefix
             value: /mcp
+        - path:
+            type: Exact
+            value: /sse
       backendRefs:
         - name: mcp
           group: agentgateway.dev


### PR DESCRIPTION
## Summary

Adds an `Exact /sse` path match to the `mcp` HTTPRoute so legacy HTTP+SSE MCP clients can connect at `https://mcp.perryhuynh.com/sse`, alongside the existing `/mcp` streamable HTTP endpoint.

agentgateway routes requests whose path is exactly `/sse` to its built-in `LegacySSEService` ([router.rs](https://github.com/agentgateway/agentgateway/blob/main/crates/agentgateway/src/mcp/router.rs)), which proxies legacy SSE downstream to streamable HTTP upstream — the `AgentgatewayBackend` targets remain `StreamableHTTP` unchanged. Legacy POST messages also use `/sse?sessionId=...`, so the single exact match covers both the GET stream and POSTs.

## Validation

- `flate test all --path kubernetes/flux/cluster --base origin/main` passes.
- Post-deploy smoke test: `curl -N -H 'Accept: text/event-stream' https://mcp.perryhuynh.com/sse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)