### PR TITLE
feat(media): add internal route for qbittorrent

### DIFF
--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -100,6 +100,18 @@ spec:
         globalMounts:
           - path: /tmp
             subPath: tmp
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.perryhuynh.com"
+        parentRefs:
+          - name: envoy-internal
+            namespace: networking
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
     service:
       app:
         forceRename: *app

--- a/kubernetes/apps/media/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qui/app/helmrelease.yaml
@@ -90,7 +90,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.perryhuynh.com"
-          - "qbittorrent.perryhuynh.com"
         parentRefs:
           - name: envoy-internal
             namespace: networking


### PR DESCRIPTION
## Summary
- Add an HTTPRoute for qbittorrent on the `envoy-internal` gateway at `qbittorrent.perryhuynh.com`, backed by the `app` service on port 80.
- Remove the `qbittorrent.perryhuynh.com` hostname alias from the qui route so it no longer shadows the new qbittorrent route.

## Validation
- `flate test all --path kubernetes/flux/cluster --base origin/main` passes (qbittorrent and qui Kustomizations/HelmReleases render clean).

## Notes
- qbittorrent's WebUI is now reachable directly at this hostname behind its own built-in auth (no OIDC gate like qui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)