### PR TITLE
feat(networking): scrape agentgateway proxy metrics

### DIFF
--- a/kubernetes/apps/networking/agentgateway/gateway/grafanadashboard.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/grafanadashboard.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: agentgateway
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  folder: networking
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: VictoriaMetrics
+  url: https://grafana.com/api/dashboards/24590/revisions/1/download

--- a/kubernetes/apps/networking/agentgateway/gateway/kustomization.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./gateway.yaml
   - ./backend.yaml
   - ./httproute.yaml
+  - ./podmonitor.yaml

--- a/kubernetes/apps/networking/agentgateway/gateway/kustomization.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./backend.yaml
   - ./httproute.yaml
   - ./podmonitor.yaml
+  - ./grafanadashboard.yaml

--- a/kubernetes/apps/networking/agentgateway/gateway/podmonitor.yaml
+++ b/kubernetes/apps/networking/agentgateway/gateway/podmonitor.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: agentgateway-proxy
+spec:
+  jobLabel: agentgateway-proxy
+  namespaceSelector:
+    matchNames:
+      - networking
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      honorLabels: true
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-class-name: agentgateway


### PR DESCRIPTION
Adds metrics scraping and a Grafana dashboard for the agentgateway data plane.

- **PodMonitor**: selects proxy pods by the `gateway.networking.k8s.io/gateway-class-name: agentgateway` label so any future agentgateway Gateways are covered automatically. The proxy exposes Prometheus metrics on the named `metrics` container port (15020, `/metrics`), including MCP-specific series (MCP calls by method, tool calls by tool). The generated `mcp` Service only exposes the 443 listener, so a ServiceMonitor cannot target it — a PodMonitor mirrors the existing envoy-proxy pattern in this repo.
- **GrafanaDashboard**: [AgentGateway Overview (24590)](https://grafana.com/grafana/dashboards/24590-agentgateway-overview/) into the networking folder, with `DS_PROMETHEUS` mapped to the VictoriaMetrics datasource.

Tracing and access-log policies are deferred until a trace backend exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)