### PR TITLE
fix(observability): allow gateway host on grafana-mcp

### DIFF
--- a/kubernetes/apps/observability/grafana-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana-mcp/app/helmrelease.yaml
@@ -15,6 +15,9 @@ spec:
       - --transport=streamable-http
       - --endpoint-path=/mcp
       - --address=0.0.0.0:8000
+      # mcp-grafana >=0.17.1 blocks DNS rebinding by allowlisting Host; agentgateway
+      # forwards the external gateway hostname, so allow it plus the in-cluster service
+      - --allowed-hosts=mcp.perryhuynh.com,grafana-mcp.observability.svc.cluster.local:8000
     grafana:
       apiKeySecret:
         name: grafana-mcp-token


### PR DESCRIPTION
mcp-grafana 0.17.1 added DNS rebinding protection ([grafana/mcp-grafana#957](https://github.com/grafana/mcp-grafana/pull/957)) that defaults the Host allowlist to loopback variants of `--address`. Requests federated through agentgateway carry `Host: mcp.perryhuynh.com`, so grafana-mcp returned `403 forbidden: host not allowed`, which failed the whole federated MCP `initialize` on `https://mcp.perryhuynh.com/mcp` (and MCP clients misread the 403 as an auth challenge).

Allowlist the gateway hostname plus the in-cluster service authority via `--allowed-hosts`. Matching is exact string including port; the external Host arrives without a port.