### PR TITLE
add kromgo ceph version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ _... managed with Flux, Renovate, and GitHub Actions_ 🤖
 [![Flux](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.perryhuynh.com%2Fbadges%2Fflux_version%3Fformat%3Dshields&style=for-the-badge&logo=flux&logoColor=326ce5&color=1a1a1a&label=%20)](https://fluxcd.io)&nbsp;&nbsp;
 [![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.perryhuynh.com%2Fbadges%2Fkubernetes_version%3Fformat%3Dshields&style=for-the-badge&logo=kubernetes&logoColor=white&color=296dea&label=%20)](https://kubernetes.io)&nbsp;&nbsp;
 [![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.perryhuynh.com%2Fbadges%2Ftalos_version%3Fformat%3Dshields&style=for-the-badge&logo=talos&logoColor=f81f25&color=433448&label=%20)](https://talos.dev)&nbsp;&nbsp;
+[![Ceph](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.perryhuynh.com%2Fbadges%2Fceph_version%3Fformat%3Dshields&style=for-the-badge&logo=ceph&logoColor=white&color=ef5c55&label=%20)](https://ceph.io)&nbsp;&nbsp;
 
 </div>
 

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -34,6 +34,11 @@ spec:
           valueExpr: labels["version_id"]
           title: Talos
 
+        - id: ceph_version
+          query: label_replace(ceph_mon_metadata, "version", "$1", "ceph_version", "ceph version ([0-9.]+) .+")
+          valueExpr: labels["version"]
+          title: Ceph
+
         - id: cluster_power_usage
           query: avg(upsAdvOutputActivePower)
           valueExpr: humanizeCommas(math.round(result)) + "w"


### PR DESCRIPTION
## Summary
- add a Kromgo badge for the live Ceph version from ceph monitor metadata
- add the Ceph version badge to the README header

## Validation
- flate test all --path kubernetes/flux/cluster