### PR TITLE
fix(suwayomi): use EXTENSION_STORES env var and index URL format

### DIFF
--- a/kubernetes/apps/media/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/media/suwayomi/app/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
             env:
               BACKUP_INTERVAL: 0
               BIND_PORT: &port 80
-              EXTENSION_SOURCES: '["https://github.com/keiyoushi/extensions/tree/repo"]'
+              EXTENSION_STORES: '["https://raw.githubusercontent.com/keiyoushi/extensions/repo/index.min.json"]'
               FLARESOLVERR_ENABLED: true
               FLARESOLVERR_URL: http://flaresolverr.default.svc.cluster.local:8191
               TZ: America/Los_Angeles


### PR DESCRIPTION
## Summary
- Renamed `EXTENSION_SOURCES` → `EXTENSION_STORES` in the suwayomi `HelmRelease` and switched the value to the new expected URL format.
- Upstream Suwayomi-Server deprecated the `extensionRepos` config key in favor of `extensionStores` (`ServerConfig.kt`, marked `@Deprecated("Will get removed")`).
- The official docker entrypoint (`Suwayomi-Server-docker/scripts/startup_script.sh`) no longer maps `EXTENSION_SOURCES` at all — it only reads `EXTENSION_STORES` into `server.extensionStores`.
- The new setting expects direct extension store index JSON URLs, not GitHub repo `tree` URLs. The old format's runtime migration regex (`repoMatchRegex`) confirms the target shape: `github.com/<owner>/<repo>/tree/<branch>` → `raw.githubusercontent.com/<owner>/<repo>/<branch>/index.min.json`.
- Verified `index.min.json` exists on keiyoushi's `repo` branch via `gh api repos/keiyoushi/extensions/contents/index.min.json?ref=repo`.

```
- EXTENSION_SOURCES: '["https://github.com/keiyoushi/extensions/tree/repo"]'
+ EXTENSION_STORES: '["https://raw.githubusercontent.com/keiyoushi/extensions/repo/index.min.json"]'
```

## Test plan
- [x] `flate test all --path kubernetes/flux/cluster --base origin/main` passes (HelmRelease/Kustomization/OCIRepository for media/suwayomi render clean)
- [ ] Confirm extensions load correctly after Flux reconciles the change in-cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)