### PR TITLE
fix(observability): revert victoria-logs chart to 0.13.8 (v1.51.0)

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/ocirepository.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.13.9
+    tag: 0.13.8
   url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-single
   verify:
     provider: cosign


### PR DESCRIPTION
Reverts the image half of #7295. Chart `0.13.9` ships VictoriaLogs `v1.52.0`, which crash-loops on ingest.

## Symptom

`victoria-logs-0` container `vlogs`: **142 restarts**, ~24/day, ~6/hour. Exit 255, `reason: Error` — not OOM.

```
"level":"panic","caller":"VictoriaLogs/lib/logstorage/stream_tags.go:234",
"msg":"FATAL: cannot unmarshal StreamTags: stream tags must be sorted in alphabetical order;
got \"service.name\" which is less or equal than \"service.name\";
streamTags={k8s.container.name=\"manager\",k8s.namespace.name=\"database\",
k8s.pod.name=\"cloudnative-pg-86b95cdfcb-c2d8w\",service.name=\"barman-cloud\",
service.name=\"cloudnative-pg\",service.namespace=\"database\",service.namespace=\"database\"}"
```

Pod survives ~20s, ingests a cloudnative-pg operator log line, panics.

## Timeline

Daily restart counts for `victoria-logs-0/vlogs`:

| Date | Restarts |
|---|---|
| Jun 10 – Jul 16 | 0 (every day) |
| Jul 17 | 14 |
| Jul 18 | 30 |
| Jul 22 | 41 |
| Jul 28 | 24 |

Series is present throughout — real zeros, not gaps. #7295 merged Jul 16 12:44 PDT; crashes begin the next day.

## Upstream

Fix exists only in the unreleased `tip` section — nothing has shipped after v1.52.0:

> BUGFIX: data ingestion and querying: properly handle logs containing duplicate stream field names. Previously, v1.52.0 could panic when ingesting such logs in single-node VictoriaLogs, drop them during ingestion in VictoriaLogs cluster, or panic when querying such data written by earlier releases.

v1.52.0's feature list includes *"adjusted `_stream` field values according to actual log fields"*, which touches the panicking code path — likely the regression's origin.

## Safety

- v1.52.0 changelog notes **no on-disk storage format change**, so the PVC written since Jul 17 reads back cleanly on v1.51.0.
- `flate test all --path kubernetes/flux/cluster --base origin/main` → `✓ 4 passed · 49 skipped`
- Rendered image confirmed: `mirror.gcr.io/victoriametrics/victoria-logs:v1.51.0`

## Follow-up (not in this PR)

The OTel pipeline emits duplicate `service.name` / `service.namespace` for some records — both are declared in `VL-Stream-Fields`, which is what makes them fatal rather than cosmetic. v1.51.0 tolerates this, so it isn't urgent, but it blocks upgrading past v1.52.0. Suspects: `logdedup` running twice (collector and gateway), or `k8s_attributes` `pod_association` falling through to `from: connection`. Unconfirmed.

Renovate will try to re-bump this. Worth a pin or ignore rule until the next VictoriaLogs release.