### PR TITLE
perf(media): reduce memory limits for plex, sonarr, and suwayomi

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
               claims:
                 - name: gpu
               limits:
-                memory: 16Gi
+                memory: 6Gi
               requests:
                 cpu: 250m
             securityContext:

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
             envFrom: *envFrom
             resources:
               limits:
-                memory: 6Gi
+                memory: 2Gi
               requests:
                 cpu: 10m
             probes:

--- a/kubernetes/apps/media/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/media/suwayomi/app/helmrelease.yaml
@@ -53,7 +53,7 @@ spec:
                   periodSeconds: 10
             resources:
               limits:
-                memory: 4Gi
+                memory: 3Gi
               requests:
                 cpu: 10m
             securityContext:


### PR DESCRIPTION
## Problem

None of these containers set `resources.requests.memory`, so Kubernetes defaults the request to the limit and each pod reserves its full burst ceiling as scheduler capacity. Lowering the limits reclaims that without introducing a `requests` stanza.

## Sizing

30-day peak working set from VictoriaMetrics (`max_over_time(container_memory_working_set_bytes[30d:1h])`, cross-checked for plex at 1m resolution over 7d to catch short transcode spikes — no hidden peaks):

| App | Limit before | 30d peak | Limit after | Headroom |
|---|---|---|---|---|
| plex | 16Gi | 3.22Gi | 6Gi | 1.9x |
| sonarr | 6Gi | 0.62Gi | 2Gi | 3.2x |
| suwayomi | 4Gi | 2.08Gi | 3Gi | 1.4x |

Frees ~15Gi of cluster memory requests. Cluster commit drops from ~164Gi to ~149Gi of 271Gi allocatable.

## Risk

These are OOM boundaries, not eviction hints — a pod exceeding its new limit is killed rather than rescheduled. suwayomi at 1.4x is the tightest entry and the one to watch after rollout.

`flate test all --path kubernetes/flux/cluster --base origin/main` passes.