### PR TITLE
feat(cnpg): use switchover for primary updates

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   instances: 3
   imageName: ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie@sha256:660141d8ac12d783f12a3f6bb5ca6c3b1412ea18881f73b9853cfb1eeb9cf128
+  primaryUpdateMethod: switchover
   primaryUpdateStrategy: unsupervised
   storage:
     size: 20Gi


### PR DESCRIPTION
Sets `spec.primaryUpdateMethod: switchover` on the `postgres` Cluster.

Previously the field was unset, defaulting to `restart`: rolling updates restart the primary in place, so writes are unavailable for the full primary restart. With `switchover`, CNPG promotes an already-updated replica and demotes the old primary, so the write outage is limited to the promotion window.

`primaryUpdateStrategy: unsupervised` is unchanged — updates still proceed automatically without manual approval.

Validated with `flate test all --path kubernetes/flux/cluster --base origin/main`.