### PR TITLE
fix(cnpg): lower postgres memory limit to 2Gi

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -24,7 +24,7 @@ spec:
       shared_buffers: 512MB
   resources:
     limits:
-      memory: 4Gi
+      memory: 2Gi
     requests:
       cpu: 100m
   monitoring:


### PR DESCRIPTION
## Change

```diff
   resources:
     limits:
-      memory: 4Gi
+      memory: 2Gi
     requests:
       cpu: 100m
```

## Why

Measured working set for container `postgres` (VictoriaMetrics, 30d):

| pod | now | avg 7d | peak 30d |
|---|---|---|---|
| postgres-1 | 112Mi | 723Mi | 861Mi |
| postgres-2 | 108Mi | 296Mi | 726Mi |
| postgres-3 | 176Mi | 309Mi | 450Mi |

Peak was 21% of the 4Gi limit, with 0 restarts / OOMKills in 30d.

No `requests.memory` is set, so Kubernetes defaults the request to the limit: each of the 3 instances reserved 4Gi (12Gi total) for a combined peak under 2.5Gi. Node memory requests were already at 56/91Gi (wizone), 34/60Gi (jo-yuri), 31/60Gi (choi-yena). Halving the limit halves the reservation to 2Gi per instance, freeing ~6Gi.

Working set here includes page cache on top of `shared_buffers: 512MB`, so that peak is already a generous ceiling. Peak backends over 30d was 48 of `max_connections: 600`, so per-backend memory is not driving usage today.

Applying this restarts the instances (memory is not in-place resizable on this cluster).

Validated with `flate test all --path kubernetes/flux/cluster --base origin/main`.