### PR TITLE
Revert "chore: add hass probes (#7424)"

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -25,28 +25,6 @@ spec:
                 valueFrom:
                   fieldRef:
                     fieldPath: status.podIP
-            probes:
-              liveness:
-                enabled: true
-                spec:
-                  periodSeconds: 30
-                  timeoutSeconds: 5
-                  failureThreshold: 5
-              readiness:
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /healthz
-                    port: &port 8123
-                  periodSeconds: 10
-                  timeoutSeconds: 5
-                  failureThreshold: 5
-              startup:
-                enabled: true
-                spec:
-                  failureThreshold: 30
-                  periodSeconds: 10
             resources:
               limits:
                 memory: 1Gi
@@ -138,7 +116,7 @@ spec:
       app:
         ports:
           http:
-            port: *port
+            port: 8123
       code-server:
         ports:
           code-server:


### PR DESCRIPTION
Reverts commit 5559383b51931851189f78b6a936d185ffeb3568, removing the liveness/readiness/startup probes added to the Home Assistant HelmRelease and restoring the literal `8123` service port (the reverted commit had replaced it with a `*port` anchor reference).

Validated with `flate test all --path kubernetes/flux/cluster --base origin/main` — 8 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)