### PR TITLE
feat: deploy dashbrr

### DIFF
--- a/kubernetes/apps/media/dashbrr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/dashbrr/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dashbrr-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    template:
+      data:
+        DASHBRR__OIDC_CLIENT_ID: "{{ .oauth_client_id }}"
+        DASHBRR__OIDC_CLIENT_SECRET: "{{ .oauth_client_secret }}"
+  dataFrom:
+    - extract:
+        key: dashbrr

--- a/kubernetes/apps/media/dashbrr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/dashbrr/app/helmrelease.yaml
@@ -1,0 +1,91 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app dashbrr
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: dashbrr
+  values:
+    controllers:
+      dashbrr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/autobrr/dashbrr
+              tag: v0.4.0@sha256:8f0df866a33b0a1a278b87654961605437bfe62d5d77ee45e9ccdf758de9bc53
+            env:
+              DASHBRR__LISTEN_ADDR: 0.0.0.0:80
+              DASHBRR__LOG_LEVEL: info
+              DASHBRR__CONFIG_PATH: /config/config.toml
+              TZ: America/Los_Angeles
+              # database
+              DASHBRR__DB_TYPE: sqlite
+              DASHBRR__DB_PATH: /config/dashbrr.db
+              # oidc
+              DASHBRR__OIDC_ISSUER: https://auth.perryhuynh.com
+              DASHBRR__OIDC_REDIRECT_URL: https://dashbrr.perryhuynh.com/api/auth/oidc/callback
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 80
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              limits:
+                memory: 256Mi
+              requests:
+                cpu: 10m
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - "ALL"
+              readOnlyRootFilesystem: true
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    persistence:
+      config:
+        existingClaim: *app
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.perryhuynh.com"
+        parentRefs:
+          - name: envoy-internal
+            namespace: networking
+            sectionName: https
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/media/dashbrr/app/kustomization.yaml
+++ b/kubernetes/apps/media/dashbrr/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/media/dashbrr/app/ocirepository.yaml
+++ b/kubernetes/apps/media/dashbrr/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dashbrr
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token.actions.githubusercontent.com$"
+        subject: "^https://github.com/bjw-s-labs/helm-charts.*$"

--- a/kubernetes/apps/media/dashbrr/ks.yaml
+++ b/kubernetes/apps/media/dashbrr/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dashbrr
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: authelia
+      namespace: security
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  interval: 1h
+  path: ./kubernetes/apps/media/dashbrr/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./namespace.yaml
   - ./autobrr/ks.yaml
   - ./brrpolice/ks.yaml
+  - ./dashbrr/ks.yaml
   - ./kavita/ks.yaml
   - ./plex/ks.yaml
   - ./prowlarr/ks.yaml

--- a/kubernetes/apps/security/authelia/app/externalsecret.yaml
+++ b/kubernetes/apps/security/authelia/app/externalsecret.yaml
@@ -35,6 +35,8 @@ spec:
         ACTUAL_OAUTH_CLIENT_SECRET: "{{ .actual_oauth_client_secret_hashed }}"
         AUTOBRR_OAUTH_CLIENT_ID: "{{ .autobrr_oauth_client_id }}"
         AUTOBRR_OAUTH_CLIENT_SECRET: "{{ .autobrr_oauth_client_secret_hashed }}"
+        DASHBRR_OAUTH_CLIENT_ID: "{{ .dashbrr_oauth_client_id }}"
+        DASHBRR_OAUTH_CLIENT_SECRET: "{{ .dashbrr_oauth_client_secret_hashed }}"
         GRAFANA_OAUTH_CLIENT_ID: "{{ .grafana_oauth_client_id }}"
         GRAFANA_OAUTH_CLIENT_SECRET: "{{ .grafana_oauth_client_secret_hashed }}"
         PAPERLESS_OAUTH_CLIENT_ID: "{{ .paperless_oauth_client_id }}"
@@ -66,6 +68,12 @@ spec:
         - regexp:
             source: "(.*)"
             target: "autobrr_$1"
+    - extract:
+        key: dashbrr
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "dashbrr_$1"
     - extract:
         key: glauth
       rewrite:

--- a/kubernetes/apps/security/authelia/app/resources/configuration.yaml
+++ b/kubernetes/apps/security/authelia/app/resources/configuration.yaml
@@ -86,6 +86,15 @@ identity_providers:
         scopes: ["openid", "profile", "groups", "email"]
         redirect_uris: ["https://autobrr.perryhuynh.com/api/auth/oidc/callback"]
         userinfo_signed_response_alg: none
+      - client_name: dashbrr
+        client_id: "${DASHBRR_OAUTH_CLIENT_ID}"
+        client_secret: "${DASHBRR_OAUTH_CLIENT_SECRET}"
+        public: false
+        authorization_policy: two_factor
+        pre_configured_consent_duration: 1y
+        scopes: ["openid", "profile", "groups", "email"]
+        redirect_uris: ["https://dashbrr.perryhuynh.com/api/auth/oidc/callback"]
+        userinfo_signed_response_alg: none
       - client_name: grafana
         client_id: ${GRAFANA_OAUTH_CLIENT_ID}
         client_secret: "${GRAFANA_OAUTH_CLIENT_SECRET}"


### PR DESCRIPTION
Deploys [dashbrr](https://github.com/autobrr/dashbrr) `v0.4.0` to the `media` namespace — autobrr's dashboard for monitoring a media stack (autobrr, *arr apps, qBittorrent/qui, Plex, seerr, Tautulli).

Follows the existing `media/qui` pattern: bjw-s `app-template` 5.0.1 via a cosign-verified `OCIRepository`, SQLite on a VolSync-backed Ceph PVC, Authelia OIDC, and an internal Gateway API route at `https://dashbrr.perryhuynh.com`.

## Upstream details

Verified against the dashbrr repo at `v0.4.0`:

| | |
|---|---|
| Listen address | `DASHBRR__LISTEN_ADDR`, set to `0.0.0.0:80` |
| Health endpoint | `GET /health`, unauthenticated (`internal/api/server.go`) |
| Database | `DASHBRR__DB_TYPE=sqlite` + `DASHBRR__DB_PATH` |
| Config file | `config.toml`, path via `DASHBRR__CONFIG_PATH` |
| OIDC callback | `/api/auth/oidc/callback` |
| Image runtime | Alpine, non-root, `WORKDIR`/`VOLUME`/`XDG_*` all `/config` |

The image sets `HOME`, `XDG_CONFIG_HOME`, and `XDG_DATA_HOME` to `/config`, and the container runs with `readOnlyRootFilesystem: true`, so the PVC is mounted at `/config` and both the SQLite file and `config.toml` are pinned there explicitly.

No `serviceMonitor` — dashbrr exposes no metrics endpoint. No Redis/Dragonfly either; its cache is in-process.

The `DASHBRR__` prefix on the OIDC variables is required as of recent releases: the old unprefixed `OIDC_*` names are ignored with a startup warning.

## Authelia

Adds a `dashbrr` OIDC client alongside the existing `qui` one, with `DASHBRR_OAUTH_CLIENT_ID` / `DASHBRR_OAUTH_CLIENT_SECRET` sourced from a new `dashbrr` 1Password item.

## Before merging

A `dashbrr` item must exist in 1Password with `oauth_client_id`, `oauth_client_secret`, and `oauth_client_secret_hashed`. Without it both ExternalSecrets stay in `SecretSyncedError` and the pods will not start.

## Validation

`flate test all --path kubernetes/flux/cluster` — 331 passed. (The `--base origin/main` changed-only mode fails with `resolve HEAD: reference not found` when run from a git worktree, so the full suite was run instead.)

Rendered output confirmed: `/config` mounted from the `dashbrr` PVC, readiness probe on `/health` port 80, HTTPRoute on `envoy-internal`, and the VolSync-generated PVC + `volsync-unlock-dashbrr` release.

## Follow-up, not in this PR

dashbrr can auto-discover services from `com.dashbrr.service.*` annotations on Services given cluster-scoped RBAC (`docs/k8s_discovery_example.yaml`). That means annotating every *arr Service and adding a ClusterRole, so it is left for a separate change once dashbrr is running with services added manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)