### PR TITLE
chore(renovate-config)!: update config home-operations/renovate-presets (5.0.0 ➔ 6.0.0)

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,7 +1,10 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "github>home-operations/renovate-presets#5.0.0",
+    "github>home-operations/renovate-presets#6.0.0",
+    "github>home-operations/renovate-presets//apps/cnpg.json5#6.0.0",
+    "github>home-operations/renovate-presets//apps/grafanaDashboards.json5#6.0.0",
+    "github>home-operations/renovate-presets//apps/talosFactory.json5#6.0.0",
     "github>perryhuynh/homelab//.renovate/allowedVersions.json5",
     "github>perryhuynh/homelab//.renovate/autoMerge.json5",
     "github>perryhuynh/homelab//.renovate/groups.json5",


### PR DESCRIPTION
Fixes the Renovate config error reported in #7454:

> Cannot find preset's package (github>home-operations/renovate-presets//managers/cnpg.json5)

## Cause

Upstream released [6.0.0](https://github.com/home-operations/renovate-presets/blob/main/CHANGELOG.md), which made app-specific presets opt-in by moving them from `managers/` and `versioning/` into `apps/`. The nested `extends` entries inside the preset repo's `default.json` are unqualified, so Renovate resolves them from the preset repo's default branch rather than our pinned `#5.0.0` tag. Once `managers/cnpg.json5` disappeared from `main`, our pinned config could no longer resolve and Renovate halted all PRs.

## Change

- Bump the root preset to `#6.0.0`.
- Explicitly extend the `apps/` presets this repo actually needs: `cnpg`, `grafanaDashboards`, `talosFactory`.

`llamacpp`, `phanpy`, and `searxng` also moved to `apps/` but are not deployed here, so they are intentionally left out.

## Verification

All four referenced preset paths confirmed present at tag 6.0.0 via the GitHub contents API. `renovate-config-validator` was not run locally: `mise` refused to install `npm:renovate` because of a supply-chain trust check on the transitive dependency `@yarnpkg/libzip@3.2.2` (3.2.0 had provenance attestation, 3.2.2 has none). Not bypassed.

Closes #7454