### PR TITLE
chore(renovate-config): bump home-operations presets to 7.0.0

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,10 +1,10 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "github>home-operations/renovate-presets#6.0.0",
-    "github>home-operations/renovate-presets//apps/cnpg.json5#6.0.0",
-    "github>home-operations/renovate-presets//apps/grafanaDashboards.json5#6.0.0",
-    "github>home-operations/renovate-presets//apps/talosFactory.json5#6.0.0",
+    "github>home-operations/renovate-presets#7.0.0",
+    "github>home-operations/renovate-presets//apps/cnpg.json5#7.0.0",
+    "github>home-operations/renovate-presets//apps/grafanaDashboards.json5#7.0.0",
+    "github>home-operations/renovate-presets//apps/talosFactory.json5#7.0.0",
     "github>perryhuynh/homelab//.renovate/allowedVersions.json5",
     "github>perryhuynh/homelab//.renovate/autoMerge.json5",
     "github>perryhuynh/homelab//.renovate/groups.json5",


### PR DESCRIPTION
Renovate is halted with:

```
Cannot find preset's package (github>home-operations/renovate-presets//config/baseConfig.json5)
```

**Cause:** upstream 7.0.0 consolidated `config/`, `managers/`, `overrides/`, and `policies/` into `default.json` and deleted those directories. Our root extend was pinned to `#6.0.0`, but 6.0.0's `default.json` extends its nested presets *without* a ref, so Renovate resolved them from the default branch (now 7.x) where the paths are gone.

**Fix:** bump all four upstream extends to `#7.0.0`.

Verified against the upstream repo at tag 7.0.0: `default.json` extends only stock Renovate presets (no nested repo paths), and `apps/cnpg.json5`, `apps/grafanaDashboards.json5`, `apps/talosFactory.json5` still exist and are self-contained. `renovate-config-validator --strict` passes.

Fixes #7465

🤖 Generated with [Claude Code](https://claude.com/claude-code)