### PR TITLE
feat(rook-ceph): rotate cephx daemon keys to aes256k

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -51,6 +51,19 @@ spec:
         urlPrefix: /
         ssl: false
         prometheusEndpoint: http://victoria-metrics.observability.svc.cluster.local:8428
+      healthCheck:
+        # Unresolvable while CSI keys stay on aes (kernel 7.0+ required for
+        # aes256k) and allowedCiphers therefore cannot be narrowed.
+        # https://rook.io/docs/rook/latest/Storage-Configuration/Advanced/cephx-key-rotation/
+        muteHealthWarning:
+          AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE:
+            policy: mute
+          AUTH_INSECURE_CLIENT_KEY_TYPE:
+            policy: mute
+          AUTH_INSECURE_KEYS_ALLOWED:
+            policy: mute
+          AUTH_INSECURE_KEYS_CREATABLE:
+            policy: mute
       mgr:
         modules:
           - name: diskprediction_local
@@ -78,6 +91,14 @@ spec:
         provider: host
         connections:
           requireMsgr2: true
+      security:
+        cephx:
+          # CVE-2025-30156: rotate core daemon keys to aes256k
+          daemon:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
+          csi:
+            keyType: aes # aes256k requires kernel 7.0+
       storage:
         useAllNodes: false
         useAllDevices: false


### PR DESCRIPTION
Adopts the CephX half of [onedr0p/home-ops@c9694d3](https://github.com/onedr0p/home-ops/commit/c9694d3716dbb62698bebd54913526199eaf8613).

## Why

The cluster runs Ceph `v20.2.4` on Rook `v1.20.5` — both new enough to support the `aes256k` CephX cipher — but the key rotation was never initiated, so every key sits at `keyGeneration: 1` / `keyCephVersion: 19.2.3-0` with the old `aes` type. Ceph is consequently in `HEALTH_ERR`:

```
[ERR] AUTH_INSECURE_SERVICE_KEY_TYPE: 6 auth service entities with insecure key types
[ERR] AUTH_INSECURE_SERVICE_TICKETS: Monitors are configured to issue insecure service tickets
```

This is step 3 of Rook's [CVE-2025-30156 quick resolution guide](https://rook.io/docs/rook/latest/Storage-Configuration/Advanced/cephx-key-rotation/#quick-resolution-guide). Until it runs, any compromised CephX key can be escalated to admin.

## What

- `security.cephx.daemon` — one-off rotation to generation 2, which moves mon/mgr/osd (and Rook's admin) keys to `aes256k` and clears both errors.
- `security.cephx.csi.keyType: aes` — pinned explicitly. Nodes run kernel `6.18.44-talos`; `aes256k` CSI keys require 7.0+. Rook already defaults us here, but the docs recommend pinning so a chart default can't rotate CSI keys out from under kernel mounts.
- `healthCheck.muteHealthWarning` — the four warnings that cannot be cleared in this environment. `CLIENT_KEY_TYPE` needs CSI on `aes256k`; `KEYS_ALLOWED`/`KEYS_CREATABLE` need `allowedCiphers: [aes256k]`, which would lock out those same CSI clients. `ROTATING_SERVICE_KEY_TYPE` self-clears 2-3h after the daemon rotation but is muted for the interim. Flip these to `unmute` if the cluster ever reaches full `aes256k`.

Not adopted from upstream: the `cephImage` pin removal and `csi.cephFSKernelMountOptions` no-op (never pinned, already on Tentacle), and `cephfs.kernelMountOptions` (`cephFileSystems: []` here).

## Rollout note

Rotation restarts mons, mgrs and OSDs. PVCs stay mounted throughout, but expect a rolling daemon restart on reconcile. Verify afterwards with `status.cephx` showing `keyGeneration: 2` and `ceph health detail` dropping both `[ERR]` lines.

## Validation

`flate test all --path kubernetes/flux/cluster --base origin/main` — 13 passed, 0 failed. Rendered `CephCluster` confirmed to carry `spec.security.cephx` and `spec.healthCheck.muteHealthWarning`.