### PR TITLE
fix(rook-ceph): disable rook mgr module

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -72,8 +72,13 @@ spec:
             enabled: true
           - name: pg_autoscaler
             enabled: true
+          # Ceph v20.2.4: the prometheus module calls node_proxy_fullreport()
+          # on every scrape, which the rook orchestrator backend does not
+          # implement, logging a mgr module crash every 15s. Fixed upstream in
+          # ceph@543c9498f but not yet in a release. Re-enable once it ships.
+          # https://medium.com/rook-io/rook-advisory-for-ceph-cve-2025-30156-cc1f8dee6da3
           - name: rook
-            enabled: true
+            enabled: false
       resources:
         mgr:
           limits:


### PR DESCRIPTION
Follow-up to #7534. Applies the `mgr.modules` half of [Rook's CVE-2025-30156 advisory](https://medium.com/rook-io/rook-advisory-for-ceph-cve-2025-30156-cc1f8dee6da3), which #7534 missed:

> ```yaml
>   mgr:
>     modules:
>       - name: rook
>         enabled: false # work around mgr crash bug in Ceph v1.20.4
> ```
> Disabling the rook module is necessary to avoid a Ceph mgr crash bug.

## Why

Ceph `v20.2.4`'s prometheus mgr module calls `node_proxy_fullreport()` on every scrape to collect node-proxy hardware metrics. That orchestrator method is only implemented by the **cephadm** backend; the **rook** backend reports `available: true` but raises:

```
File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 369, in node_proxy_fullreport
    raise NotImplementedError()
```

Ceph records that as a mgr module crash every 15s, pinning the cluster at `HEALTH_WARN RECENT_MGR_MODULE_CRASH`. Archiving is not a fix — **123 new crashes accumulated within 28 minutes** of running `ceph crash archive-all`, with ~120 matching log lines per 10 minutes.

Ceph fixed the call site in [ceph@543c9498f](https://github.com/ceph/ceph/commit/543c9498f) ("mgr/prometheus: skip get_hardware_metrics() on non-cephadm backends", 2026-08-11) by reading the orchestrator backend from config and returning early when it isn't cephadm. That landed after the `v20.2.4` cut and is not in a release yet, so the module has to stay off for now — the comment in the manifest records when to revert.

## Trade-off

Disabling the module drops the `ceph orch` backend (currently `Backend: rook / Available: Yes`) and the Ceph dashboard's orchestrator-backed host/device/service views. The Rook operator itself does not depend on it — the module serves the Ceph → Rook direction, and Rook reconciles CRs directly. `diskprediction_local` and `device_failure_prediction_mode: local` read device health metrics from the mons/OSDs and are unaffected.

## Validation

`flate test all --path kubernetes/flux/cluster --base origin/main` — 13 passed, 0 failed. Rendered `CephCluster` shows `rook` at `enabled: false` with the other three modules untouched.

Post-merge the accumulated crashes need one `kubectl rook-ceph ceph crash archive-all` to clear the existing warning; with the module off they should not come back.