### PR TITLE
feat(sonarr): set allowed hosts and trusted networks

### DIFF
--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -44,7 +44,9 @@ spec:
               SONARR__AUTH__REQUIRED: DisabledForLocalAddresses
               SONARR__LOG__DBENABLED: "false"
               SONARR__LOG__LEVEL: info
+              SONARR__SERVER__ALLOWEDHOSTS: sonarr.perryhuynh.com,sonarr.media.svc.cluster.local
               SONARR__SERVER__PORT: &port 80
+              SONARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               TZ: America/Los_Angeles
             envFrom: *envFrom
             resources:
@@ -66,6 +68,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 5


### PR DESCRIPTION
Adopts [onedr0p/home-ops@b543061](https://github.com/onedr0p/home-ops/commit/b543061c2d3b8b6519c9c4c9ead5a3a455bfb8ea), adjusted for this cluster.

- `SONARR__SERVER__ALLOWEDHOSTS`: restricts accepted Host headers to `sonarr.perryhuynh.com` and `sonarr.media.svc.cluster.local`.
- `SONARR__SERVER__TRUSTEDNETWORKS`: `10.42.0.0/16`, matching `clusterPodNets` in `talos/talconfig.yaml`.
- Readiness probe now sends a `Host: localhost` header, since kubelet probes use the pod IP as the Host and would otherwise be rejected by the allowed-hosts filter.

Radarr and Prowlarr use the same pattern but are intentionally left alone here, matching the scope of the upstream commit.

Validated with `flate test all --path kubernetes/flux/cluster --base origin/main`.